### PR TITLE
Fix AppEngine tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ bin/
 .classpath
 .settings
 .project
-
+*.iml
+.idea

--- a/google-api-client-appengine/src/main/java/com/google/api/client/googleapis/extensions/appengine/testing/auth/oauth2/MockAppIdentityService.java
+++ b/google-api-client-appengine/src/main/java/com/google/api/client/googleapis/extensions/appengine/testing/auth/oauth2/MockAppIdentityService.java
@@ -89,4 +89,7 @@ public class MockAppIdentityService implements AppIdentityService {
   public ParsedAppId parseFullAppId(String fullAppId) {
     return null;
   }
+
+  @Override
+  public String getDefaultGcsBucketName() { return null; }
 }


### PR DESCRIPTION
Updating the appengine sdk in #1178 introduced a new abstract method that was not implemented.