### PR TITLE
 App Engine standard uses Java 7 or Java 8, not 6 and not 9 or later

### DIFF
--- a/google-api-client-appengine/pom.xml
+++ b/google-api-client-appengine/pom.xml
@@ -71,7 +71,7 @@
           </execution>
         </executions>
       </plugin>
-      <!--App Engine uses Java 7 and above-->
+      <!--App Engine uses Java 7 or Java 8 -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>

--- a/google-api-client-appengine/pom.xml
+++ b/google-api-client-appengine/pom.xml
@@ -16,7 +16,7 @@
         <configuration>
           <links>
             <link>http://download.oracle.com/javase/6/docs/api/</link>
-            <link>http://code.google.com/appengine/docs/java/javadoc</link>
+            <link>https://cloud.google.com/appengine/docs/standard/java/javadoc/</link>
             <link>http://javadoc.google-http-java-client.googlecode.com/hg/${project.http.version}</link>
             <link>http://javadoc.google-oauth-java-client.googlecode.com/hg/${project.oauth.version}</link>
           </links>
@@ -71,14 +71,14 @@
           </execution>
         </executions>
       </plugin>
-      <!--App Engine uses Java 6 and above-->
+      <!--App Engine uses Java 7 and above-->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java16</artifactId>
+            <artifactId>java17</artifactId>
             <version>1.0</version>
           </signature>
         </configuration>


### PR DESCRIPTION
 @chingor13 Fixes #1180 

- [X ] Tests pass
- [ X] Appropriate docs were updated (if necessary)
