### PR TITLE
Release google-api-java-client v1.27.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ To use Maven, add the following lines to your pom.xml file:
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.0</version>
       </dependency>
     </dependencies>
   </project>
@@ -211,7 +211,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.26.0'
+    compile 'com.google.api-client:google-api-client:1.27.0'
 }
 ```
 [//]: # ({x-version-update-end})

--- a/google-api-client-android/pom.xml
+++ b/google-api-client-android/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-android</artifactId>

--- a/google-api-client-appengine/pom.xml
+++ b/google-api-client-appengine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-appengine</artifactId>

--- a/google-api-client-assembly/pom.xml
+++ b/google-api-client-assembly/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>com.google.api-client</groupId>

--- a/google-api-client-bom/README.md
+++ b/google-api-client-bom/README.md
@@ -5,14 +5,14 @@ versions of `google-api-client` components.
 
 To use it in Maven, add the following to your `pom.xml`:
 
-[//]: # ({x-version-update-start:google-api-client-bom:released})
+[//]: # ({x-version-update-start:google-api-client:released})
 ```xml
 <dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client-bom</artifactId>
-      <version>1.26.0</version>
+      <version>1.27.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/google-api-client-bom/pom.xml
+++ b/google-api-client-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api-client</groupId>
   <artifactId>google-api-client-bom</artifactId>
-  <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client-bom:current} -->
+  <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
   <packaging>pom</packaging>
 
   <name>Google API Client Library for Java BOM</name>
@@ -51,52 +51,52 @@
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-android</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-appengine</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-assembly</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-gson</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-jackson2</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-java6</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-protobuf</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-servlet</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-xml</artifactId>
-        <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-api-client-gson/pom.xml
+++ b/google-api-client-gson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-gson</artifactId>

--- a/google-api-client-jackson2/pom.xml
+++ b/google-api-client-jackson2/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-jackson2</artifactId>

--- a/google-api-client-java6/pom.xml
+++ b/google-api-client-java6/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-java6</artifactId>

--- a/google-api-client-protobuf/pom.xml
+++ b/google-api-client-protobuf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-protobuf</artifactId>

--- a/google-api-client-servlet/pom.xml
+++ b/google-api-client-servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-servlet</artifactId>

--- a/google-api-client-xml/pom.xml
+++ b/google-api-client-xml/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-xml</artifactId>

--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.google.api-client</groupId>
   <artifactId>google-api-client-parent</artifactId>
-  <version>1.26.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+  <version>1.27.0</version><!-- {x-version-update:google-api-client:current} -->
   <packaging>pom</packaging>
   <name>Parent for the Google API Client Library for Java</name>
 
@@ -528,8 +528,8 @@
       - Internally, update the default features.json file
     -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.http.version>1.26.0</project.http.version><!-- {x-version-update:google-http-client:released} -->
-    <project.oauth.version>1.26.0</project.oauth.version><!-- {x-version-update:google-oauth-client:released} -->
+    <project.http.version>1.27.0</project.http.version><!-- {x-version-update:google-http-client:released} -->
+    <project.oauth.version>1.27.0</project.oauth.version><!-- {x-version-update:google-oauth-client:released} -->
     <project.jsr305.version>3.0.2</project.jsr305.version>
     <project.gson.version>2.1</project.gson.version>
     <project.jackson-core-asl.version>1.9.13</project.jackson-core-asl.version>

--- a/versions.txt
+++ b/versions.txt
@@ -1,6 +1,6 @@
 # Format:
 # module:released-version:current-version
 
-google-api-client:1.26.0:1.26.1-SNAPSHOT
-google-http-client:1.26.0:1.26.1-SNAPSHOT
-google-oauth-client:1.26.0:1.26.1-SNAPSHOT
+google-api-client:1.27.0:1.27.0
+google-http-client:1.27.0:1.27.0
+google-oauth-client:1.27.0:1.27.0


### PR DESCRIPTION
This pull request was generated using releasetool.

11-09-2018 12:56 PST

### Implementation Changes
- Delay request initialization for resumable upload ([#1211](https://github.com/google/google-api-java-client/pull/1211))
- Fix possible NPE when missing os.version system property ([#1210](https://github.com/google/google-api-java-client/pull/1210))

### New Features
- Add google-api-client-bom artifact ([#1213](https://github.com/google/google-api-java-client/pull/1213))

### Dependencies
- Remove datanucleus dependency ([#1183](https://github.com/google/google-api-java-client/pull/1183))

### Internal / Testing Changes
- Release improvements ([#1195](https://github.com/google/google-api-java-client/pull/1195))
- Bump next snapshot ([#1194](https://github.com/google/google-api-java-client/pull/1194))