### PR TITLE
Remove usage of deprecated Backoff from google-http-java-client

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/batch/BatchRequest.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/batch/BatchRequest.java
@@ -14,7 +14,6 @@
 
 package com.google.api.client.googleapis.batch;
 
-import com.google.api.client.http.BackOffPolicy;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpBackOffUnsuccessfulResponseHandler;
 import com.google.api.client.http.HttpExecuteInterceptor;
@@ -93,7 +92,6 @@ import java.util.List;
  * @since 1.9
  * @author rmistry@google.com (Ravi Mistry)
  */
-@SuppressWarnings("deprecation")
 public final class BatchRequest {
 
   /** The URL where batch requests are sent. */
@@ -220,12 +218,6 @@ public final class BatchRequest {
     HttpExecuteInterceptor originalInterceptor = batchRequest.getInterceptor();
     batchRequest.setInterceptor(new BatchInterceptor(originalInterceptor));
     int retriesRemaining = batchRequest.getNumberOfRetries();
-    BackOffPolicy backOffPolicy = batchRequest.getBackOffPolicy();
-
-    if (backOffPolicy != null) {
-      // Reset the BackOffPolicy at the start of each execute.
-      backOffPolicy.reset();
-    }
 
     do {
       retryAllowed = retriesRemaining > 0;
@@ -259,17 +251,6 @@ public final class BatchRequest {
       List<RequestInfo<?, ?>> unsuccessfulRequestInfos = batchResponse.unsuccessfulRequestInfos;
       if (!unsuccessfulRequestInfos.isEmpty()) {
         requestInfos = unsuccessfulRequestInfos;
-        // backOff if required.
-        if (batchResponse.backOffRequired && backOffPolicy != null) {
-          long backOffTime = backOffPolicy.getNextBackOffMillis();
-          if (backOffTime != BackOffPolicy.STOP) {
-            try {
-              sleeper.sleep(backOffTime);
-            } catch (InterruptedException exception) {
-              // ignore
-            }
-          }
-        }
       } else {
         break;
       }

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/batch/BatchUnparsedResponse.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/batch/BatchUnparsedResponse.java
@@ -15,7 +15,6 @@
 package com.google.api.client.googleapis.batch;
 
 import com.google.api.client.googleapis.batch.BatchRequest.RequestInfo;
-import com.google.api.client.http.BackOffPolicy;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpContent;
 import com.google.api.client.http.HttpHeaders;
@@ -42,7 +41,6 @@ import java.util.List;
  *
  * @author rmistry@google.com (Ravi Mistry)
  */
-@SuppressWarnings("deprecation")
 final class BatchUnparsedResponse {
 
   /** The boundary used in the batch response to separate individual responses. */
@@ -59,9 +57,6 @@ final class BatchUnparsedResponse {
 
   /** List of unsuccessful HTTP requests that can be retried. */
   List<RequestInfo<?, ?>> unsuccessfulRequestInfos = new ArrayList<RequestInfo<?, ?>>();
-
-  /** Indicates if back off is required before the next retry. */
-  boolean backOffRequired;
 
   /** The content Id the response is currently at. */
   private int contentId = 0;
@@ -183,10 +178,6 @@ final class BatchUnparsedResponse {
     HttpHeaders responseHeaders = response.getHeaders();
     HttpUnsuccessfulResponseHandler unsuccessfulResponseHandler =
         requestInfo.request.getUnsuccessfulResponseHandler();
-    BackOffPolicy backOffPolicy = requestInfo.request.getBackOffPolicy();
-
-    // Reset backOff flag.
-    backOffRequired = false;
 
     if (HttpStatusCodes.isSuccess(statusCode)) {
       if (callback == null) {
@@ -207,12 +198,9 @@ final class BatchUnparsedResponse {
       if (!errorHandled) {
         if (requestInfo.request.handleRedirect(response.getStatusCode(), response.getHeaders())) {
           redirectRequest = true;
-        } else if (retrySupported && backOffPolicy != null
-            && backOffPolicy.isBackOffRequired(response.getStatusCode())) {
-          backOffRequired = true;
         }
       }
-      if (retrySupported && (errorHandled || backOffRequired || redirectRequest)) {
+      if (retrySupported && (errorHandled || redirectRequest)) {
         unsuccessfulRequestInfos.add(requestInfo);
       } else {
         if (callback == null) {


### PR DESCRIPTION
BackoffPolicy was deprecated in google-http-java-client which was scheduled for deletion in March 2014!