### PR TITLE
Compile to Java 1.7 binary

### DIFF
--- a/google-api-client-android/pom.xml
+++ b/google-api-client-android/pom.xml
@@ -16,7 +16,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>
           <windowtitle>${project.artifactId} ${project.version}</windowtitle>

--- a/google-api-client-appengine/pom.xml
+++ b/google-api-client-appengine/pom.xml
@@ -15,7 +15,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>https://cloud.google.com/appengine/docs/standard/java/javadoc/</link>
             <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
             <link>https://googleapis.github.io/google-oauth-java-client/releases/${project.oauth.version}/javadoc/</link>

--- a/google-api-client-gson/pom.xml
+++ b/google-api-client-gson/pom.xml
@@ -15,7 +15,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>

--- a/google-api-client-jackson2/pom.xml
+++ b/google-api-client-jackson2/pom.xml
@@ -15,7 +15,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>

--- a/google-api-client-java6/pom.xml
+++ b/google-api-client-java6/pom.xml
@@ -15,7 +15,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>
@@ -51,7 +51,7 @@
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java16</artifactId>
+            <artifactId>java17</artifactId>
             <version>1.0</version>
           </signature>
         </configuration>

--- a/google-api-client-protobuf/pom.xml
+++ b/google-api-client-protobuf/pom.xml
@@ -22,7 +22,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>

--- a/google-api-client-servlet/pom.xml
+++ b/google-api-client-servlet/pom.xml
@@ -15,7 +15,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
             <link>https://googleapis.github.io/google-oauth-java-client/releases/${project.oauth.version}/javadoc/</link>
           </links>

--- a/google-api-client-xml/pom.xml
+++ b/google-api-client-xml/pom.xml
@@ -15,7 +15,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>http://download.oracle.com/javase/6/docs/api/</link>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
             <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
           </links>
           <doctitle>${project.name} ${project.version}</doctitle>

--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -22,7 +22,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
-            <link>https://docs.oracle.com/javase/6/docs/api/</link>
+            <link>https://docs.oracle.com/javase/7/docs/api/</link>
             <link>https://cloud.google.com/appengine/docs/standard/java/javadoc/</link>
             <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
             <link>https://googleapis.github.io/google-oauth-java-client/releases/${project.oauth.version}/javadoc/</link>

--- a/pom.xml
+++ b/pom.xml
@@ -397,7 +397,7 @@
             <phase>site</phase>
             <configuration>
               <links>
-                <link>http://download.oracle.com/javase/6/docs/api/</link>
+                <link>http://download.oracle.com/javase/7/docs/api/</link>
                 <link>http://cloud.google.com/appengine/docs/java/javadoc</link>
                 <link>https://googleapis.github.io/google-http-java-client/releases/${project.http.version}/javadoc/</link>
                 <link>https://googleapis.github.io/google-oauth-java-client/releases/${project.oauth.version}/javadoc/</link>
@@ -499,7 +499,7 @@
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java16</artifactId>
+            <artifactId>java17</artifactId>
             <version>1.0</version>
           </signature>
         </configuration>


### PR DESCRIPTION
We're dropping Java 6 in the next release, so set the maven-compiler to use source level 1.7 and to compile to 1.7 binary. Also update animal-sniffer-plugin to java17 to allow 1.7 source.