### PR TITLE
edited and removed some redundancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Google APIs Client Library for Java
 
-- [Library maintenance](#maintenance)
+- [Library Maintenance](#maintenance)
 - [Overview](#Overview)
 - [Highlighted Features](#Highlighted_Features)
 - [Dependencies](#Dependencies)
@@ -10,8 +10,8 @@
 - [Documentation](#Documentation)
 - [Links](#Links)
 
-## Library maintenance
-These client libraries are official supported by Google. However, these libraries are considered complete and are in maintenance mode. This means that we will address critical bugs and security issues but will not add any new features. If you're working with **Google Cloud Platform** APIs such as Datastore, Pub/Sub and many others,
+## Library Maintenance
+These client libraries are officially supported by Google. However, these libraries are considered complete and are in maintenance mode. This means that we will address critical bugs and security issues, but will not add any new features. If you're working with **Google Cloud Platform** APIs such as Datastore, Pub/Sub and many others,
 consider using the [Cloud Client Libraries for Java](https://github.com/GoogleCloudPlatform/google-cloud-java)
 instead. These are the new and idiomatic Java libraries targeted specifically at Google Cloud
 Platform Services.
@@ -81,10 +81,9 @@ If you are using the old GData library, you need to
 ### Developing for Android
 
 If you are developing for Android and the Google API you want to use is included in the
-[Google Play Services library](https://developer.android.com/google/play-services/index.html), you
-should use that library for the best performance and experience.
+[Google Play Services library](https://developer.android.com/google/play-services/index.html), use that library for the best performance and experience.
 
-To access other Google APIs, you can use the Google APIs Client Library for Java, which supports
+To access other Google APIs, use the Google APIs Client Library for Java, which supports
 [Android 4.0 (Ice Cream Sandwich) (or higher)](https://developers.google.com/api-client-library/java/google-api-java-client/android).
 
 ### Other Java environments
@@ -160,10 +159,10 @@ protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IO
 
 If you are developing for Android and the Google API you want to use is included in the
 [Google Play Services library](https://developer.android.com/google/play-services/index.html),
-you should use that library for the best performance and experience.
+use that library for the best performance and experience.
 
-To access other Google APIs, you can use the Google Client Library for Java's Android-specific
-helper classes, which are are well-integrated with
+To access other Google APIs, use the Google Client Library for Java's Android-specific
+helper classes, which are well-integrated with
 [Android AccountManager](http://developer.android.com/reference/android/accounts/AccountManager.html).
 For example:
 
@@ -261,7 +260,7 @@ might result, and you are not guaranteed a compilation error.
 ## Notice: Ending Java 6 Support
 
 Please note: since Java 6 extended support is being ended this December by Oracle, we will begin
-ending Java 6 support in early 2019, with release 1.28.0 as a tentative goal. Users may stay still
+ending Java 6 support in early 2019, with release 1.28.0 as a tentative goal. Users may still
 use these libraries in Java 6 projects for some time, but going forward we will not ensure that
 these libraries work in such an environment. After 1.28.0, our supported versions will include Java
 7 and onward.


### PR DESCRIPTION
Fixes: Capitalized and made the Heading style under main "Google APIs Client Library for Java" similar.
Removed extra "are" in line 166 and extra word, "stay" from content, and removed some such errors and redundancy. 