### PR TITLE
Release google-api-java-client v1.28.0

### DIFF
--- a/.kokoro/release/drop.sh
+++ b/.kokoro/release/drop.sh
@@ -15,11 +15,18 @@
 
 set -eo pipefail
 
-source $(dirname "$0")/common.sh
+# STAGING_REPOSITORY_ID must be set
+if [ -z "${STAGING_REPOSITORY_ID}" ]; then
+  echo "Missing STAGING_REPOSITORY_ID environment variable"
+  exit 1
+fi
 
+source $(dirname "$0")/common.sh
 pushd $(dirname "$0")/../../
 
 setup_environment_secrets
 create_settings_xml_file "settings.xml"
 
-mvn nexus-staging:drop --settings=settings.xml
+mvn nexus-staging:drop -B \
+  --settings=settings.xml \
+  -DstagingRepositoryId=${STAGING_REPOSITORY_ID}

--- a/.kokoro/release/promote.sh
+++ b/.kokoro/release/promote.sh
@@ -15,6 +15,12 @@
 
 set -eo pipefail
 
+# STAGING_REPOSITORY_ID must be set
+if [ -z "${STAGING_REPOSITORY_ID}" ]; then
+  echo "Missing STAGING_REPOSITORY_ID environment variable"
+  exit 1
+fi
+
 source $(dirname "$0")/common.sh
 
 pushd $(dirname "$0")/../../
@@ -22,4 +28,7 @@ pushd $(dirname "$0")/../../
 setup_environment_secrets
 create_settings_xml_file "settings.xml"
 
-mvn nexus-staging:release -DperformRelease=true --settings=settings.xml
+mvn nexus-staging:release -B \
+  -DperformRelease=true \
+  --settings=settings.xml \
+  -DstagingRepositoryId=${STAGING_REPOSITORY_ID}

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ To use Maven, add the following lines to your pom.xml file:
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
-        <version>1.27.0</version>
+        <version>1.28.0</version>
       </dependency>
     </dependencies>
   </project>
@@ -210,7 +210,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.27.0'
+    compile 'com.google.api-client:google-api-client:1.28.0'
 }
 ```
 [//]: # ({x-version-update-end})

--- a/google-api-client-android/pom.xml
+++ b/google-api-client-android/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-android</artifactId>

--- a/google-api-client-appengine/pom.xml
+++ b/google-api-client-appengine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-appengine</artifactId>

--- a/google-api-client-assembly/pom.xml
+++ b/google-api-client-assembly/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>com.google.api-client</groupId>

--- a/google-api-client-bom/README.md
+++ b/google-api-client-bom/README.md
@@ -12,7 +12,7 @@ To use it in Maven, add the following to your `pom.xml`:
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client-bom</artifactId>
-      <version>1.27.0</version>
+      <version>1.28.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/google-api-client-bom/pom.xml
+++ b/google-api-client-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api-client</groupId>
   <artifactId>google-api-client-bom</artifactId>
-  <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+  <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
   <packaging>pom</packaging>
 
   <name>Google API Client Library for Java BOM</name>
@@ -63,52 +63,52 @@
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
-        <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-android</artifactId>
-        <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-appengine</artifactId>
-        <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-assembly</artifactId>
-        <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-gson</artifactId>
-        <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-jackson2</artifactId>
-        <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-java6</artifactId>
-        <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-protobuf</artifactId>
-        <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-servlet</artifactId>
-        <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-xml</artifactId>
-        <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-api-client-gson/pom.xml
+++ b/google-api-client-gson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-gson</artifactId>

--- a/google-api-client-jackson2/pom.xml
+++ b/google-api-client-jackson2/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-jackson2</artifactId>

--- a/google-api-client-java6/pom.xml
+++ b/google-api-client-java6/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-java6</artifactId>

--- a/google-api-client-protobuf/pom.xml
+++ b/google-api-client-protobuf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-protobuf</artifactId>

--- a/google-api-client-servlet/pom.xml
+++ b/google-api-client-servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-servlet</artifactId>

--- a/google-api-client-xml/pom.xml
+++ b/google-api-client-xml/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-xml</artifactId>

--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client</artifactId>

--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -102,6 +102,10 @@
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-apache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-gson</artifactId>
       <scope>test</scope>
     </dependency>

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/apache/GoogleApacheHttpTransport.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/apache/GoogleApacheHttpTransport.java
@@ -17,9 +17,20 @@ package com.google.api.client.googleapis.apache;
 import com.google.api.client.googleapis.GoogleUtils;
 import com.google.api.client.http.apache.ApacheHttpTransport;
 
+import com.google.api.client.util.SslUtils;
 import java.io.IOException;
+import java.net.ProxySelector;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLContext;
+import org.apache.http.client.HttpClient;
+import org.apache.http.config.SocketConfig;
+import org.apache.http.conn.socket.LayeredConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
 
 /**
  * Utilities for Google APIs based on {@link ApacheHttpTransport}.
@@ -31,13 +42,41 @@ public final class GoogleApacheHttpTransport {
 
   /**
    * Returns a new instance of {@link ApacheHttpTransport} that uses
-   * {@link GoogleUtils#getCertificateTrustStore()} for the trusted certificates using
-   * {@link com.google.api.client.http.apache.ApacheHttpTransport.Builder#trustCertificates(KeyStore)}.
+   * {@link GoogleUtils#getCertificateTrustStore()} for the trusted certificates.
    */
   public static ApacheHttpTransport newTrustedTransport() throws GeneralSecurityException,
       IOException {
-    return new ApacheHttpTransport.Builder().trustCertificates(
-        GoogleUtils.getCertificateTrustStore()).build();
+    // Set socket buffer sizes to 8192
+    SocketConfig socketConfig =
+        SocketConfig.custom()
+            .setRcvBufSize(8192)
+            .setSndBufSize(8192)
+            .build();
+
+    PoolingHttpClientConnectionManager connectionManager =
+        new PoolingHttpClientConnectionManager(-1, TimeUnit.MILLISECONDS);
+
+    // Disable the stale connection check (previously configured in the HttpConnectionParams
+    connectionManager.setValidateAfterInactivity(-1);
+
+    // Use the included trust store
+    KeyStore trustStore = GoogleUtils.getCertificateTrustStore();
+    SSLContext sslContext = SslUtils.getTlsSslContext();
+    SslUtils.initSslContext(sslContext, trustStore, SslUtils.getPkixTrustManagerFactory());
+    LayeredConnectionSocketFactory socketFactory = new SSLConnectionSocketFactory(sslContext);
+
+    HttpClient client = HttpClientBuilder.create()
+        .useSystemProperties()
+        .setSSLSocketFactory(socketFactory)
+        .setDefaultSocketConfig(socketConfig)
+        .setMaxConnTotal(200)
+        .setMaxConnPerRoute(20)
+        .setRoutePlanner(new SystemDefaultRoutePlanner(ProxySelector.getDefault()))
+        .setConnectionManager(connectionManager)
+        .disableRedirectHandling()
+        .disableAutomaticRetries()
+        .build();
+    return new ApacheHttpTransport(client);
   }
 
   private GoogleApacheHttpTransport() {

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,11 @@
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-apache</artifactId>
+        <version>${project.http-apache.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-appengine</artifactId>
         <version>${project.http.version}</version>
       </dependency>
@@ -544,6 +549,7 @@
     -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.http.version>1.28.0</project.http.version><!-- {x-version-update:google-http-client:released} -->
+    <project.http-apache.version>2.0.0</project.http-apache.version><!-- {x-version-update:google-http-client-apache:released} -->
     <project.oauth.version>1.28.0</project.oauth.version><!-- {x-version-update:google-oauth-client:released} -->
     <project.jsr305.version>3.0.2</project.jsr305.version>
     <project.gson.version>2.1</project.gson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.google.api-client</groupId>
   <artifactId>google-api-client-parent</artifactId>
-  <version>1.27.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+  <version>1.28.0</version><!-- {x-version-update:google-api-client:current} -->
   <packaging>pom</packaging>
   <name>Parent for the Google API Client Library for Java</name>
 
@@ -543,8 +543,8 @@
       - Internally, update the default features.json file
     -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.http.version>1.27.0</project.http.version><!-- {x-version-update:google-http-client:released} -->
-    <project.oauth.version>1.27.0</project.oauth.version><!-- {x-version-update:google-oauth-client:released} -->
+    <project.http.version>1.28.0</project.http.version><!-- {x-version-update:google-http-client:released} -->
+    <project.oauth.version>1.28.0</project.oauth.version><!-- {x-version-update:google-oauth-client:released} -->
     <project.jsr305.version>3.0.2</project.jsr305.version>
     <project.gson.version>2.1</project.gson.version>
     <project.jackson-core-asl.version>1.9.13</project.jackson-core-asl.version>

--- a/versions.txt
+++ b/versions.txt
@@ -1,6 +1,6 @@
 # Format:
 # module:released-version:current-version
 
-google-api-client:1.27.0:1.27.1-SNAPSHOT
-google-http-client:1.27.0:1.27.1-SNAPSHOT
-google-oauth-client:1.27.0:1.27.1-SNAPSHOT
+google-api-client:1.28.0:1.28.0
+google-http-client:1.28.0:1.28.0
+google-oauth-client:1.28.0:1.28.0

--- a/versions.txt
+++ b/versions.txt
@@ -3,4 +3,5 @@
 
 google-api-client:1.28.0:1.28.0
 google-http-client:1.28.0:1.28.0
+google-http-client-apache:2.0.0:2.0.0
 google-oauth-client:1.28.0:1.28.0


### PR DESCRIPTION
This pull request was generated using releasetool.

01-14-2019 13:18 PST

### Breaking Changes
- Java 6 support was dropped ([#1222](https://github.com/google/google-oauth-java-client/pull/1222))

### Implementation Changes
- Handle the legacy endpoint in the MockTokenServerTransport ([#1232](https://github.com/google/google-api-java-client/pull/1232))
- Set expires_in to an hour instead of 1000 hours ([#1229](https://github.com/google/google-api-java-client/pull/1229))

### Deprecations
- Remove ClientLogin ([#1224](https://github.com/google/google-api-java-client/pull/1224))
- Remove usage of deprecated Backoff from google-http-java-client ([#1221](https://github.com/google/google-api-java-client/pull/1221))

### Dependencies
- Update guava to 26.0-android ([#1218](https://github.com/google/google-api-java-client/pull/1218))

### Documentation
- Fix old links to code.google.com  ([#1225](https://github.com/google/google-api-java-client/pull/1225))
- Update README: edited and removed some redundancy ([#1226](https://github.com/google/google-api-java-client/pull/1226))

### Internal / Testing Changes
- Use maven enforcer plugin for maven version requirements ([#1228](https://github.com/google/google-api-java-client/pull/1228))
- Add Java 11 test configs ([#1223](https://github.com/google/google-api-java-client/pull/1223))
