### PR TITLE
Deprecate the GoogleCredential and CloudShellCredential classes

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/CloudShellCredential.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/CloudShellCredential.java
@@ -46,7 +46,10 @@ import java.util.List;
  * OAuth2 credentials representing the built-in service account for Google Cloud Shell.
  *
  * @since 1.21.0
+ * @deprecated Please use <a href="https://github.com/googleapis/google-auth-library-java">
+ *   google-auth-library</a> for handling authentication and authorization from Cloud Shell.
  */
+@Deprecated
 public class CloudShellCredential extends GoogleCredential {
 
   private static final int ACCESS_TOKEN_INDEX = 2;

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleCredential.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleCredential.java
@@ -164,7 +164,11 @@ import java.util.Collections;
  *
  * @since 1.7
  * @author Yaniv Inbar
+ * @deprecated Please use <a href="https://github.com/googleapis/google-auth-library-java">
+ *   google-auth-library</a> for handling Application Default Credentials and other non-OAuth2
+ *   based authentication.
  */
+@Deprecated
 public class GoogleCredential extends Credential {
 
   static final String USER_FILE_TYPE = "authorized_user";


### PR DESCRIPTION
The fancy automatic credentials for Application Default Credentials and CloudShell should be handled by [google-auth-library](https://github.com/googleapis/google-auth-library-java). That library provides [an adapter](https://github.com/googleapis/google-auth-library-java/blob/master/oauth2_http/java/com/google/auth/http/HttpCredentialsAdapter.java) that can be used with google-http-client.

Note that this still provides the oauth2 helpers for handling 3-legged OAuth2.