### PR TITLE
Update http/oauth dependencies to 1.29

### DIFF
--- a/google-api-client-appengine/pom.xml
+++ b/google-api-client-appengine/pom.xml
@@ -53,7 +53,7 @@
         </executions>
         <configuration>
           <instructions>
-            <Bundle-DocURL>https://googleapis.dev/java/google-api-client/1.28.0/index.html</Bundle-DocURL>
+            <Bundle-DocURL>https://googleapis.dev/java/google-api-client/${project.version}/index.html</Bundle-DocURL>
             <Bundle-Description>App Engine extensions to the Google APIs Client Library for Java</Bundle-Description>
             <Bundle-SymbolicName>com.google.api.client.appengine</Bundle-SymbolicName>
           </instructions>

--- a/google-api-client-gson/pom.xml
+++ b/google-api-client-gson/pom.xml
@@ -51,7 +51,7 @@
         </executions>
         <configuration>
           <instructions>
-            <Bundle-DocURL>https://googleapis.dev/java/google-api-client/1.28.0/index.html</Bundle-DocURL>
+            <Bundle-DocURL>https://googleapis.dev/java/google-api-client/${project.version}/index.html</Bundle-DocURL>
             <Bundle-Description>GSON extensions to the Google APIs Client Library for Java</Bundle-Description>
             <Bundle-SymbolicName>com.google.api.client.googleapis.notifications.json.gson</Bundle-SymbolicName>
           </instructions>

--- a/google-api-client-jackson2/pom.xml
+++ b/google-api-client-jackson2/pom.xml
@@ -51,7 +51,7 @@
         </executions>
         <configuration>
           <instructions>
-            <Bundle-DocURL>https://googleapis.dev/java/google-api-client/1.28.0/index.html</Bundle-DocURL>
+            <Bundle-DocURL>https://googleapis.dev/java/google-api-client/${project.version}/index.html</Bundle-DocURL>
             <Bundle-Description>Low-level implementation of the JSON parser library based on the Jackson 2 JSON library.</Bundle-Description>
             <Bundle-SymbolicName>com.google.api.client.jackson2</Bundle-SymbolicName>
           </instructions>

--- a/google-api-client-java6/pom.xml
+++ b/google-api-client-java6/pom.xml
@@ -51,7 +51,7 @@
         </executions>
         <configuration>
           <instructions>
-            <Bundle-DocURL>https://googleapis.dev/java/google-api-client/1.28.0/index.html</Bundle-DocURL>
+            <Bundle-DocURL>https://googleapis.dev/java/google-api-client/${project.version}/index.html</Bundle-DocURL>
             <Bundle-Description>Java 6 extensions to the Google APIs Client Library for Java</Bundle-Description>
             <Bundle-SymbolicName>com.google.api.client.java6</Bundle-SymbolicName>
           </instructions>

--- a/google-api-client-protobuf/pom.xml
+++ b/google-api-client-protobuf/pom.xml
@@ -58,7 +58,7 @@
         </executions>
         <configuration>
           <instructions>
-            <Bundle-DocURL>https://googleapis.dev/java/google-api-client/1.28.0/index.html</Bundle-DocURL>
+            <Bundle-DocURL>https://googleapis.dev/java/google-api-client/${project.version}/index.html</Bundle-DocURL>
             <Bundle-Description>Protobuf extensions to the Google APIs Client Library for Java</Bundle-Description>
             <Bundle-SymbolicName>com.google.api.client.protobuf</Bundle-SymbolicName>
           </instructions>
@@ -105,6 +105,11 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/google-api-client-protobuf/pom.xml
+++ b/google-api-client-protobuf/pom.xml
@@ -110,7 +110,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <scope>test</scope>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 </project>

--- a/google-api-client-servlet/pom.xml
+++ b/google-api-client-servlet/pom.xml
@@ -52,7 +52,7 @@
         </executions>
         <configuration>
           <instructions>
-            <Bundle-DocURL>https://googleapis.dev/java/google-api-client/1.28.0/index.html</Bundle-DocURL>
+            <Bundle-DocURL>https://googleapis.dev/java/google-api-client/${project.version}/index.html</Bundle-DocURL>
             <Bundle-Description>Servlet extensions to the Google APIs Client Library for Java</Bundle-Description>
             <Bundle-SymbolicName>com.google.api.client.servlet</Bundle-SymbolicName>
           </instructions>

--- a/google-api-client-xml/pom.xml
+++ b/google-api-client-xml/pom.xml
@@ -51,7 +51,7 @@
         </executions>
         <configuration>
           <instructions>
-            <Bundle-DocURL>https://googleapis.dev/java/google-api-client/1.28.0/index.html</Bundle-DocURL>
+            <Bundle-DocURL>https://googleapis.dev/java/google-api-client/${project.version}/index.html</Bundle-DocURL>
             <Bundle-Description>XML extensions to the Google APIs Client Library for Java</Bundle-Description>
             <Bundle-SymbolicName>com.google.api.client.xml</Bundle-SymbolicName>
           </instructions>

--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -106,10 +106,6 @@
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client-apache</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-gson</artifactId>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -164,11 +164,6 @@
       </dependency>
       <dependency>
         <groupId>com.google.http-client</groupId>
-        <artifactId>google-http-client-apache</artifactId>
-        <version>${project.http-apache.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-appengine</artifactId>
         <version>${project.http.version}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,13 @@
         <artifactId>google-play-services</artifactId>
         <version>1</version>
       </dependency>
+
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${project.protobuf-java.version}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -554,9 +561,8 @@
       - Internally, update the default features.json file
     -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.http.version>1.28.0</project.http.version><!-- {x-version-update:google-http-client:released} -->
-    <project.http-apache.version>2.0.0</project.http-apache.version><!-- {x-version-update:google-http-client-apache:released} -->
-    <project.oauth.version>1.28.0</project.oauth.version><!-- {x-version-update:google-oauth-client:released} -->
+    <project.http.version>1.29.1</project.http.version>
+    <project.oauth.version>1.29.0</project.oauth.version>
     <project.jsr305.version>3.0.2</project.jsr305.version>
     <project.gson.version>2.1</project.gson.version>
     <project.jackson-core-asl.version>1.9.13</project.jackson-core-asl.version>

--- a/versions.txt
+++ b/versions.txt
@@ -2,6 +2,3 @@
 # module:released-version:current-version
 
 google-api-client:1.28.0:1.28.1-SNAPSHOT
-google-http-client:1.28.0:1.28.1-SNAPSHOT
-google-http-client-apache:2.0.0:2.0.1-SNAPSHOT
-google-oauth-client:1.28.0:1.28.1-SNAPSHOT


### PR DESCRIPTION
* Bump oauth and http client dependencies.
* Stop version bumping for oauth and http clients at release time