### PR TITLE
Release google-api-java-client v1.29.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ To use Maven, add the following lines to your pom.xml file:
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
-        <version>1.28.0</version>
+        <version>1.29.0</version>
       </dependency>
     </dependencies>
   </project>
@@ -210,7 +210,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.28.0'
+    compile 'com.google.api-client:google-api-client:1.29.0'
 }
 ```
 [//]: # ({x-version-update-end})

--- a/google-api-client-android/pom.xml
+++ b/google-api-client-android/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-android</artifactId>

--- a/google-api-client-appengine/pom.xml
+++ b/google-api-client-appengine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-appengine</artifactId>

--- a/google-api-client-assembly/pom.xml
+++ b/google-api-client-assembly/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>com.google.api-client</groupId>

--- a/google-api-client-bom/README.md
+++ b/google-api-client-bom/README.md
@@ -12,7 +12,7 @@ To use it in Maven, add the following to your `pom.xml`:
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client-bom</artifactId>
-      <version>1.28.0</version>
+      <version>1.29.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/google-api-client-bom/pom.xml
+++ b/google-api-client-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api-client</groupId>
   <artifactId>google-api-client-bom</artifactId>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
   <packaging>pom</packaging>
 
   <name>Google API Client Library for Java BOM</name>
@@ -63,52 +63,52 @@
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-android</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-appengine</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-assembly</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-gson</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-jackson2</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-java6</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-protobuf</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-servlet</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-xml</artifactId>
-        <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-api-client-gson/pom.xml
+++ b/google-api-client-gson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-gson</artifactId>

--- a/google-api-client-jackson2/pom.xml
+++ b/google-api-client-jackson2/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-jackson2</artifactId>

--- a/google-api-client-java6/pom.xml
+++ b/google-api-client-java6/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-java6</artifactId>

--- a/google-api-client-protobuf/pom.xml
+++ b/google-api-client-protobuf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-protobuf</artifactId>

--- a/google-api-client-servlet/pom.xml
+++ b/google-api-client-servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-servlet</artifactId>

--- a/google-api-client-xml/pom.xml
+++ b/google-api-client-xml/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-xml</artifactId>

--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.google.api-client</groupId>
   <artifactId>google-api-client-parent</artifactId>
-  <version>1.28.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+  <version>1.29.0</version><!-- {x-version-update:google-api-client:current} -->
   <packaging>pom</packaging>
   <name>Parent for the Google API Client Library for Java</name>
 

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
 # Format:
 # module:released-version:current-version
 
-google-api-client:1.28.0:1.28.1-SNAPSHOT
+google-api-client:1.29.0:1.29.0


### PR DESCRIPTION
This pull request was generated using releasetool.

05-20-2019 10:18 PDT

### Implementation Changes
- Deprecate the GoogleCredential and CloudShellCredential classes ([#1258](https://github.com/google/google-api-java-client/pull/1258))
- More OSGI metadata ([#1253](https://github.com/google/google-api-java-client/pull/1253))
- Fix OSGI metadata for gson and jackson2 packages ([#1251](https://github.com/google/google-api-java-client/pull/1251))
- Fix Replaced invalidateToken method to clearToken ([#1243](https://github.com/google/google-api-java-client/pull/1243))
- Infinite cycle with MediaHttpDownloader setContentRange download ([#1242](https://github.com/google/google-api-java-client/pull/1242))
- Check for null to prevent autoboxing NPE. ([#1241](https://github.com/google/google-api-java-client/pull/1241))
- Changed to Guava ByteStreams.copy() that has a bit better performance ([#1239](https://github.com/google/google-api-java-client/pull/1239))

### New Features
- Add automatic module name ([#1235](https://github.com/google/google-api-java-client/pull/1235))

### Dependencies
- Update http/oauth dependencies to 1.29 ([#1259](https://github.com/google/google-api-java-client/pull/1259))

### Documentation
- Fix doc links to googleapis.dev ([#1257](https://github.com/google/google-api-java-client/pull/1257))
- Bring comment in line with code ([#1246](https://github.com/google/google-api-java-client/pull/1246))

### Internal / Testing Changes
- Add publish_javadoc kokoro job ([#1248](https://github.com/google/google-api-java-client/pull/1248))