### PR TITLE
Release google-api-java-client v1.30.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ To use Maven, add the following lines to your pom.xml file:
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
-        <version>1.29.0</version>
+        <version>1.30.0</version>
       </dependency>
     </dependencies>
   </project>
@@ -210,7 +210,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.29.0'
+    compile 'com.google.api-client:google-api-client:1.30.0'
 }
 ```
 [//]: # ({x-version-update-end})

--- a/google-api-client-android/pom.xml
+++ b/google-api-client-android/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-android</artifactId>

--- a/google-api-client-appengine/pom.xml
+++ b/google-api-client-appengine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-appengine</artifactId>

--- a/google-api-client-assembly/pom.xml
+++ b/google-api-client-assembly/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>com.google.api-client</groupId>

--- a/google-api-client-bom/README.md
+++ b/google-api-client-bom/README.md
@@ -12,7 +12,7 @@ To use it in Maven, add the following to your `pom.xml`:
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client-bom</artifactId>
-      <version>1.29.0</version>
+      <version>1.30.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/google-api-client-bom/pom.xml
+++ b/google-api-client-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api-client</groupId>
   <artifactId>google-api-client-bom</artifactId>
-  <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+  <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
   <packaging>pom</packaging>
 
   <name>Google API Client Library for Java BOM</name>
@@ -63,52 +63,52 @@
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
-        <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-android</artifactId>
-        <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-appengine</artifactId>
-        <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-assembly</artifactId>
-        <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-gson</artifactId>
-        <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-jackson2</artifactId>
-        <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-java6</artifactId>
-        <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-protobuf</artifactId>
-        <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-servlet</artifactId>
-        <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-xml</artifactId>
-        <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-api-client-gson/pom.xml
+++ b/google-api-client-gson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-gson</artifactId>

--- a/google-api-client-jackson2/pom.xml
+++ b/google-api-client-jackson2/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-jackson2</artifactId>

--- a/google-api-client-java6/pom.xml
+++ b/google-api-client-java6/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-java6</artifactId>

--- a/google-api-client-protobuf/pom.xml
+++ b/google-api-client-protobuf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-protobuf</artifactId>

--- a/google-api-client-servlet/pom.xml
+++ b/google-api-client-servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-servlet</artifactId>

--- a/google-api-client-xml/pom.xml
+++ b/google-api-client-xml/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-xml</artifactId>

--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client</artifactId>

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
@@ -225,7 +225,11 @@ public abstract class AbstractGoogleClientRequest<T> extends GenericData {
     return disableGZipContent;
   }
 
-  /** Returns whether response should return raw input stream. */
+  /**
+   * Returns whether response should return raw input stream.
+   *
+   * @since 1.30
+   * */
   public final boolean getReturnRawInputSteam() {
     return returnRawInputStream;
   }
@@ -260,6 +264,8 @@ public abstract class AbstractGoogleClientRequest<T> extends GenericData {
    * chunks (see <a href="https://github.com/googleapis/google-api-java-client/issues/1009">#1009
    * </a>). Setting this to true will make the response return the raw input stream.
    * </p>
+   *
+   * @since 1.30
    */
   public AbstractGoogleClientRequest<T> setReturnRawInputStream(boolean returnRawInputStream) {
     this.returnRawInputStream = returnRawInputStream;

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/services/CommonGoogleClientRequestInitializer.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/services/CommonGoogleClientRequestInitializer.java
@@ -150,6 +150,8 @@ public class CommonGoogleClientRequestInitializer implements GoogleClientRequest
 
   /**
    * Returns new builder.
+   *
+   * @since 1.30
    */
   public static Builder newBuilder() {
     return new Builder();
@@ -198,13 +200,15 @@ public class CommonGoogleClientRequestInitializer implements GoogleClientRequest
     return requestReason;
   }
 
-  /** Returns the user project of {@code null} */
+  /** Returns the user project or {@code null}. */
   public final String getUserProject() {
     return userProject;
   }
 
   /**
    * Builder for {@code CommonGoogleClientRequestInitializer}.
+   *
+   * @since 1.30
    */
   public static class Builder {
     private String key;

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/services/json/CommonGoogleJsonClientRequestInitializer.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/services/json/CommonGoogleJsonClientRequestInitializer.java
@@ -137,6 +137,8 @@ public class CommonGoogleJsonClientRequestInitializer extends CommonGoogleClient
 
   /**
    * Builder for {@code CommonGoogleJsonClientRequestInitializer}.
+   *
+   * @since 1.30
    */
   public static class Builder extends CommonGoogleClientRequestInitializer.Builder {
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.google.api-client</groupId>
   <artifactId>google-api-client-parent</artifactId>
-  <version>1.29.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+  <version>1.30.0</version><!-- {x-version-update:google-api-client:current} -->
   <packaging>pom</packaging>
   <name>Parent for the Google API Client Library for Java</name>
 

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
 # Format:
 # module:released-version:current-version
 
-google-api-client:1.29.0:1.29.1-SNAPSHOT
+google-api-client:1.30.0:1.30.0


### PR DESCRIPTION
This pull request was generated using releasetool.

06-18-2019 08:59 PDT

### New Features
- Extensible client options ([#1263](https://github.com/google/google-api-java-client/pull/1263))
- Add option to return raw input stream for response ([#1323](https://github.com/google/google-api-java-client/pull/1323))

### Dependencies
- Update dependency org.apache.httpcomponents:httpclient to v4.5.9 ([#1316](https://github.com/google/google-api-java-client/pull/1316))
- Group AppEngine deps for renovate
- Import google-http-client-bom and google-oauth-client-bom. ([#1309](https://github.com/google/google-api-java-client/pull/1309))
- Update dependency com.google.http-client:google-http-client to v1.30.0 ([#1307](https://github.com/google/google-api-java-client/pull/1307))
- Update dependency com.google.oauth-client:google-oauth-client to v1.29.2 ([#1290](https://github.com/google/google-api-java-client/pull/1290))
- Update dependency com.google.http-client:google-http-client to v1.29.2 ([#1288](https://github.com/google/google-api-java-client/pull/1288))
- Update dependency org.codehaus.mojo:findbugs-maven-plugin to v3 ([#1287](https://github.com/google/google-api-java-client/pull/1287))
- Update dependency org.apache.maven.plugins:maven-source-plugin to v3 ([#1286](https://github.com/google/google-api-java-client/pull/1286))
- Update dependency org.sonatype.plugins:nexus-staging-maven-plugin to v1.6.8 ([#1283](https://github.com/google/google-api-java-client/pull/1283))
- Update dependency org.codehaus.mojo:findbugs-maven-plugin to v2.5.5 ([#1282](https://github.com/google/google-api-java-client/pull/1282))
- Update dependency org.apache.maven.plugins:maven-source-plugin to v2.4 ([#1280](https://github.com/google/google-api-java-client/pull/1280))
- Update dependency org.apache.maven.plugins:maven-jar-plugin to v3.1.2 ([#1278](https://github.com/google/google-api-java-client/pull/1278))
- Update dependency org.apache.maven.plugins:maven-javadoc-plugin to v3.1.0 ([#1279](https://github.com/google/google-api-java-client/pull/1279))
- Update dependency org.apache.httpcomponents:httpclient to v4.5.8 ([#1277](https://github.com/google/google-api-java-client/pull/1277))
- Update dependency kr.motd.maven:os-maven-plugin to v1.6.2 ([#1276](https://github.com/google/google-api-java-client/pull/1276))
- Update dependency junit:junit to v4.12 ([#1275](https://github.com/google/google-api-java-client/pull/1275))
- Update dependency commons-codec:commons-codec to v1.12 ([#1273](https://github.com/google/google-api-java-client/pull/1273))
- Update jackson2 version 2.9.6 -> 2.9.8 ([#1262](https://github.com/google/google-api-java-client/pull/1262))
- Remove non existing http client assembly pom dependency ([#1322](https://github.com/google/google-api-java-client/pull/1322))
- Add renovate.json ([#1265](https://github.com/google/google-api-java-client/pull/1265))

### Internal / Testing Changes
- Enable autorelease ([#1313](https://github.com/google/google-api-java-client/pull/1313))
- Bump next snapshot ([#1266](https://github.com/google/google-api-java-client/pull/1266))