### PR TITLE
Release google-api-java-client v1.30.1

### DIFF
--- a/.kokoro/release/stage.sh
+++ b/.kokoro/release/stage.sh
@@ -27,18 +27,17 @@ pushd $(dirname "$0")/../../
 setup_environment_secrets
 create_settings_xml_file "settings.xml"
 
-AUTORELEASE="false"
-if [[ -n "${AUTORELEASE_PR}" ]]
-then
-  AUTORELEASE="true"
-fi
-
 mvn clean install deploy -B \
   --settings settings.xml \
   -DperformRelease=true \
   -Dgpg.executable=gpg \
   -Dgpg.passphrase=${GPG_PASSPHRASE} \
-  -Dgpg.homedir=${GPG_HOMEDIR} \
-  -Ddeploy.autorelease=${AUTORELEASE}
+  -Dgpg.homedir=${GPG_HOMEDIR}
 
 
+if [[ -n "${AUTORELEASE_PR}" ]]
+then
+  mvn nexus-staging:release -B \
+    -DperformRelease=true \
+    --settings=settings.xml
+fi

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ To use Maven, add the following lines to your pom.xml file:
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
-        <version>1.30.0</version>
+        <version>1.30.1</version>
       </dependency>
     </dependencies>
   </project>
@@ -210,7 +210,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.30.0'
+    compile 'com.google.api-client:google-api-client:1.30.1'
 }
 ```
 [//]: # ({x-version-update-end})

--- a/google-api-client-android/pom.xml
+++ b/google-api-client-android/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-android</artifactId>

--- a/google-api-client-appengine/pom.xml
+++ b/google-api-client-appengine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-appengine</artifactId>

--- a/google-api-client-assembly/pom.xml
+++ b/google-api-client-assembly/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>com.google.api-client</groupId>

--- a/google-api-client-bom/README.md
+++ b/google-api-client-bom/README.md
@@ -12,7 +12,7 @@ To use it in Maven, add the following to your `pom.xml`:
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client-bom</artifactId>
-      <version>1.30.0</version>
+      <version>1.30.1</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/google-api-client-bom/pom.xml
+++ b/google-api-client-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api-client</groupId>
   <artifactId>google-api-client-bom</artifactId>
-  <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+  <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
   <packaging>pom</packaging>
 
   <name>Google API Client Library for Java BOM</name>
@@ -63,52 +63,52 @@
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
-        <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-android</artifactId>
-        <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-appengine</artifactId>
-        <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-assembly</artifactId>
-        <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-gson</artifactId>
-        <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-jackson2</artifactId>
-        <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-java6</artifactId>
-        <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-protobuf</artifactId>
-        <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-servlet</artifactId>
-        <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-xml</artifactId>
-        <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-api-client-gson/pom.xml
+++ b/google-api-client-gson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-gson</artifactId>

--- a/google-api-client-jackson2/pom.xml
+++ b/google-api-client-jackson2/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-jackson2</artifactId>

--- a/google-api-client-java6/pom.xml
+++ b/google-api-client-java6/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-java6</artifactId>

--- a/google-api-client-protobuf/pom.xml
+++ b/google-api-client-protobuf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-protobuf</artifactId>

--- a/google-api-client-servlet/pom.xml
+++ b/google-api-client-servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-servlet</artifactId>

--- a/google-api-client-xml/pom.xml
+++ b/google-api-client-xml/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-xml</artifactId>

--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.google.api-client</groupId>
   <artifactId>google-api-client-parent</artifactId>
-  <version>1.30.1-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+  <version>1.30.1</version><!-- {x-version-update:google-api-client:current} -->
   <packaging>pom</packaging>
   <name>Parent for the Google API Client Library for Java</name>
 

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
 # Format:
 # module:released-version:current-version
 
-google-api-client:1.30.0:1.30.1-SNAPSHOT
+google-api-client:1.30.1:1.30.1


### PR DESCRIPTION
This pull request was generated using releasetool.

06-19-2019 16:53 PDT

### Implementation Changes
- Close InputStream on error during resumable upload ([#1324](https://github.com/google/google-api-java-client/pull/1324))

### Dependencies
- Update dependency com.google.oauth-client:google-oauth-client-bom to v1.30.1 ([#1314](https://github.com/google/google-api-java-client/pull/1314))
- Update dependency com.google.http-client:google-http-client-bom to v1.30.1 ([#1311](https://github.com/google/google-api-java-client/pull/1311))

### Internal / Testing Changes
- Bump next snapshot ([#1328](https://github.com/google/google-api-java-client/pull/1328))