### PR TITLE
Release google-api-java-client v1.26.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ To use Maven, add the following lines to your pom.xml file:
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
-        <version>1.26.0</version>
+        <version>1.26.1</version>
       </dependency>
     </dependencies>
   </project>
@@ -211,7 +211,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.26.0'
+    compile 'com.google.api-client:google-api-client:1.26.1'
 }
 ```
 [//]: # ({x-version-update-end})

--- a/google-api-client-android/pom.xml
+++ b/google-api-client-android/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.0</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.26.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-android</artifactId>

--- a/google-api-client-appengine/pom.xml
+++ b/google-api-client-appengine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.0</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.26.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-appengine</artifactId>

--- a/google-api-client-assembly/pom.xml
+++ b/google-api-client-assembly/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.0</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.26.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>com.google.api-client</groupId>

--- a/google-api-client-gson/pom.xml
+++ b/google-api-client-gson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.0</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.26.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-gson</artifactId>

--- a/google-api-client-jackson2/pom.xml
+++ b/google-api-client-jackson2/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.0</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.26.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-jackson2</artifactId>

--- a/google-api-client-java6/pom.xml
+++ b/google-api-client-java6/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.0</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.26.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-java6</artifactId>

--- a/google-api-client-protobuf/pom.xml
+++ b/google-api-client-protobuf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.0</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.26.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-protobuf</artifactId>

--- a/google-api-client-servlet/pom.xml
+++ b/google-api-client-servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.0</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.26.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-servlet</artifactId>

--- a/google-api-client-xml/pom.xml
+++ b/google-api-client-xml/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.0</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.26.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-xml</artifactId>

--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.26.0</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.26.1</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client</artifactId>

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/GoogleUtils.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/GoogleUtils.java
@@ -49,7 +49,7 @@ public final class GoogleUtils {
    *
    * @since 1.14
    */
-  public static final Integer BUGFIX_VERSION = 0;
+  public static final Integer BUGFIX_VERSION = 1;
 
   /** Current release version. */
   // NOTE: toString() so compiler thinks it isn't a constant, so it won't inline it

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.google.api-client</groupId>
   <artifactId>google-api-client-parent</artifactId>
-  <version>1.26.0</version><!-- {x-version-update:google-api-client:current} -->
+  <version>1.26.1</version><!-- {x-version-update:google-api-client:current} -->
   <packaging>pom</packaging>
   <name>Parent for the Google API Client Library for Java</name>
 
@@ -527,8 +527,8 @@
       - Internally, update the default features.json file
     -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.http.version>1.26.0</project.http.version><!-- {x-version-update:google-http-client:current} -->
-    <project.oauth.version>1.26.0</project.oauth.version><!-- {x-version-update:google-oauth-client:current} -->
+    <project.http.version>1.26.1</project.http.version><!-- {x-version-update:google-http-client:current} -->
+    <project.oauth.version>1.26.1</project.oauth.version><!-- {x-version-update:google-oauth-client:current} -->
     <project.jsr305.version>3.0.2</project.jsr305.version>
     <project.gson.version>2.1</project.gson.version>
     <project.jackson-core-asl.version>1.9.13</project.jackson-core-asl.version>

--- a/versions.txt
+++ b/versions.txt
@@ -1,6 +1,6 @@
 # Format:
 # module:released-version:current-version
 
-google-api-client:1.26.0:1.26.0
-google-http-client:1.26.0:1.26.0
-google-oauth-client:1.26.0:1.26.0
+google-api-client:1.26.1:1.26.1
+google-http-client:1.26.1:1.26.1
+google-oauth-client:1.26.1:1.26.1


### PR DESCRIPTION
This pull request was generated using releasetool.

07-01-2019 15:09 PDT

### Implementation Changes
- Deprecate BatchRequest constructor ([#1333](https://github.com/google/google-api-java-client/pull/1333))