### PR TITLE
Release google-api-java-client v1.30.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To use Maven, add the following lines to your pom.xml file:
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
-        <version>1.30.2</version>
+        <version>1.30.3</version>
       </dependency>
     </dependencies>
   </project>
@@ -47,7 +47,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compile 'com.google.api-client:google-api-client:1.30.2'
+    compile 'com.google.api-client:google-api-client:1.30.3'
 }
 ```
 [//]: # ({x-version-update-end})

--- a/google-api-client-android/pom.xml
+++ b/google-api-client-android/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-android</artifactId>

--- a/google-api-client-appengine/pom.xml
+++ b/google-api-client-appengine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-appengine</artifactId>

--- a/google-api-client-assembly/pom.xml
+++ b/google-api-client-assembly/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>com.google.api-client</groupId>

--- a/google-api-client-bom/README.md
+++ b/google-api-client-bom/README.md
@@ -12,7 +12,7 @@ To use it in Maven, add the following to your `pom.xml`:
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client-bom</artifactId>
-      <version>1.30.2</version>
+      <version>1.30.3</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/google-api-client-bom/pom.xml
+++ b/google-api-client-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api-client</groupId>
   <artifactId>google-api-client-bom</artifactId>
-  <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+  <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
   <packaging>pom</packaging>
 
   <name>Google API Client Library for Java BOM</name>
@@ -63,52 +63,52 @@
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client</artifactId>
-        <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-android</artifactId>
-        <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-appengine</artifactId>
-        <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-assembly</artifactId>
-        <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-gson</artifactId>
-        <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-jackson2</artifactId>
-        <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-java6</artifactId>
-        <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-protobuf</artifactId>
-        <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-servlet</artifactId>
-        <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api-client</groupId>
         <artifactId>google-api-client-xml</artifactId>
-        <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+        <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-api-client-gson/pom.xml
+++ b/google-api-client-gson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-gson</artifactId>

--- a/google-api-client-jackson2/pom.xml
+++ b/google-api-client-jackson2/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-jackson2</artifactId>

--- a/google-api-client-java6/pom.xml
+++ b/google-api-client-java6/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-java6</artifactId>

--- a/google-api-client-protobuf/pom.xml
+++ b/google-api-client-protobuf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-protobuf</artifactId>

--- a/google-api-client-servlet/pom.xml
+++ b/google-api-client-servlet/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-servlet</artifactId>

--- a/google-api-client-xml/pom.xml
+++ b/google-api-client-xml/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client-xml</artifactId>

--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.api-client</groupId>
     <artifactId>google-api-client-parent</artifactId>
-    <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+    <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>google-api-client</artifactId>

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/GoogleUtils.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/GoogleUtils.java
@@ -35,7 +35,7 @@ public final class GoogleUtils {
   // NOTE: toString() so compiler thinks it isn't a constant, so it won't inline it
   // {x-version-update-start:google-api-client:current}
   /** Current release version. */
-  public static final String VERSION = "1.30.3-SNAPSHOT".toString();
+  public static final String VERSION = "1.30.3".toString();
   // {x-version-update-end:google-api-client:current}
 
   // NOTE: Integer instead of int so compiler thinks it isn't a constant, so it won't inline it

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>com.google.api-client</groupId>
   <artifactId>google-api-client-parent</artifactId>
-  <version>1.30.3-SNAPSHOT</version><!-- {x-version-update:google-api-client:current} -->
+  <version>1.30.3</version><!-- {x-version-update:google-api-client:current} -->
   <packaging>pom</packaging>
   <name>Parent for the Google API Client Library for Java</name>
 

--- a/versions.txt
+++ b/versions.txt
@@ -1,4 +1,4 @@
 # Format:
 # module:released-version:current-version
 
-google-api-client:1.30.2:1.30.3-SNAPSHOT
+google-api-client:1.30.3:1.30.3


### PR DESCRIPTION
This pull request was generated using releasetool.

09-12-2019 15:56 PDT

### Implementation Changes
- Update x-goog-api-client header to use gl-java and gdcl tokens ([#1354](https://github.com/google/google-api-java-client/pull/1354))
- Fix VERSION constant ([#1355](https://github.com/google/google-api-java-client/pull/1355))

### Dependencies
- deps: update dependency com.google.oauth-client:google-oauth-client-bom to v1.30.2 ([#1376](https://github.com/google/google-api-java-client/pull/1376))
- deps: update project.http.version to v1.32.0 ([#1374](https://github.com/google/google-api-java-client/pull/1374))
- deps: update App Engine SDK to 1.9.65, animal-sniffer to 1.16 ([#1364](https://github.com/google/google-api-java-client/pull/1364))
- deps: update protobuf to 3.9.1 ([#1365](https://github.com/google/google-api-java-client/pull/1365))
- Update dependency org.apache.maven.plugins:maven-javadoc-plugin to v3.1.1 ([#1344](https://github.com/google/google-api-java-client/pull/1344))
- remove unused Maven properties and update Guava to 28.0-android ([#1351](https://github.com/google/google-api-java-client/pull/1351))
- Update project.http.version to v1.31.0 ([#1347](https://github.com/google/google-api-java-client/pull/1347))
- Update dependency commons-codec:commons-codec to v1.13 ([#1349](https://github.com/google/google-api-java-client/pull/1349))
- Update dependency org.apache.maven.plugins:maven-site-plugin to v3.8.2 ([#1350](https://github.com/google/google-api-java-client/pull/1350))

### Documentation
- fix README showing version update region tag

### Internal / Testing Changes
- build: regenerate common files from templates ([#1373](https://github.com/google/google-api-java-client/pull/1373))
- build: fix snapshot script to be executable ([#1371](https://github.com/google/google-api-java-client/pull/1371))
- build: regenerated common build templates ([#1369](https://github.com/google/google-api-java-client/pull/1369))
- build: regenerated common build templates ([#1367](https://github.com/google/google-api-java-client/pull/1367))
- chore: update common templates and move README content ([#1353](https://github.com/google/google-api-java-client/pull/1353))
- Specify versions for plugins in the bom pom.xml ([#1356](https://github.com/google/google-api-java-client/pull/1356))
- Bump next snapshot ([#1336](https://github.com/google/google-api-java-client/pull/1336))