### PR TITLE
Add details to GoogleJsonResponseExceptions created with GoogleJsonResponseExceptionFactoryTesting

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/testing/json/GoogleJsonResponseExceptionFactoryTesting.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/testing/json/GoogleJsonResponseExceptionFactoryTesting.java
@@ -17,6 +17,7 @@ package com.google.api.client.googleapis.testing.json;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
+import com.google.api.client.json.Json;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.testing.http.HttpTesting;
 import com.google.api.client.testing.http.MockHttpTransport;

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/testing/json/GoogleJsonResponseExceptionFactoryTesting.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/testing/json/GoogleJsonResponseExceptionFactoryTesting.java
@@ -59,7 +59,10 @@ public final class GoogleJsonResponseExceptionFactoryTesting {
     MockLowLevelHttpResponse otherServiceUnavaiableLowLevelResponse =
         new MockLowLevelHttpResponse()
         .setStatusCode(httpCode)
-        .setReasonPhrase(reasonPhrase);
+        .setReasonPhrase(reasonPhrase)
+        .setContentType(Json.MEDIA_TYPE)
+        .setContent("{ \"error\": { \"errors\": [ { \"reason\": \"" + reasonPhrase + "\" } ], " +
+                                    "\"code\": " + httpCode + " } }");
     MockHttpTransport otherTransport = new MockHttpTransport.Builder()
         .setLowLevelHttpResponse(otherServiceUnavaiableLowLevelResponse)
         .build();


### PR DESCRIPTION
Currently, `GoogleJsonResponseException`s created with `GoogleJsonResponseExceptionFactoryTesting` will have null `#getDetails()`.