### PR TITLE
fix: add version in userAgent requestHeaders

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/GoogleUtils.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/GoogleUtils.java
@@ -35,7 +35,7 @@ public final class GoogleUtils {
   // NOTE: toString() so compiler thinks it isn't a constant, so it won't inline it
   // {x-version-update-start:google-api-client:current}
   /** Current release version. */
-  public static final String VERSION = "1.30.3".toString();
+  public static final String VERSION = "1.30.5".toString();
   // {x-version-update-end:google-api-client:current}
 
   // NOTE: Integer instead of int so compiler thinks it isn't a constant, so it won't inline it

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
@@ -126,7 +126,7 @@ public abstract class AbstractGoogleClientRequest<T> extends GenericData {
     // application name
     String applicationName = abstractGoogleClient.getApplicationName();
     if (applicationName != null) {
-      requestHeaders.setUserAgent(applicationName + GoogleUtils.VERSION + " " + USER_AGENT_SUFFIX);
+      requestHeaders.setUserAgent(applicationName + "/" + GoogleUtils.VERSION + " " + USER_AGENT_SUFFIX);
     } else {
       requestHeaders.setUserAgent(USER_AGENT_SUFFIX);
     }

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
@@ -126,7 +126,7 @@ public abstract class AbstractGoogleClientRequest<T> extends GenericData {
     // application name
     String applicationName = abstractGoogleClient.getApplicationName();
     if (applicationName != null) {
-      requestHeaders.setUserAgent(applicationName + " " + USER_AGENT_SUFFIX);
+      requestHeaders.setUserAgent(applicationName + GoogleUtils.VERSION + " " + USER_AGENT_SUFFIX);
     } else {
       requestHeaders.setUserAgent(USER_AGENT_SUFFIX);
     }

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequestTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequestTest.java
@@ -12,6 +12,7 @@
 
 package com.google.api.client.googleapis.services;
 
+import com.google.api.client.googleapis.GoogleUtils;
 import com.google.api.client.googleapis.services.AbstractGoogleClientRequest.ApiClientVersion;
 import com.google.api.client.googleapis.testing.services.MockGoogleClient;
 import com.google.api.client.googleapis.testing.services.MockGoogleClientRequest;
@@ -203,7 +204,7 @@ public class AbstractGoogleClientRequestTest extends TestCase {
     AssertUserAgentTransport transport = new AssertUserAgentTransport();
     // Specify an Application Name.
     String applicationName = "Test Application";
-    transport.expectedUserAgent = applicationName + " "
+    transport.expectedUserAgent = applicationName + GoogleUtils.VERSION + " "
         + AbstractGoogleClientRequest.USER_AGENT_SUFFIX + " "
         + HttpRequest.USER_AGENT_SUFFIX;
     MockGoogleClient client = new MockGoogleClient.Builder(


### PR DESCRIPTION
Context:
Surface version in the User-Agent header. The change updates the userAgent value to include 'GoogleUtils.VERSION'.