### PR TITLE
fix: grab version from package metadata

### DIFF
--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -19,6 +19,17 @@
     </extensions>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>resources</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <links>
@@ -94,6 +105,16 @@
         </executions>
       </plugin>
     </plugins>
+
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+      <resource>
+        <directory>src/main/properties</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
   </build>
   <dependencies>
     <dependency>

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/GoogleUtils.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/GoogleUtils.java
@@ -16,11 +16,11 @@ package com.google.api.client.googleapis;
 
 import com.google.api.client.util.SecurityUtils;
 import com.google.common.annotations.VisibleForTesting;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
+import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -32,11 +32,8 @@ import java.util.regex.Pattern;
  */
 public final class GoogleUtils {
 
-  // NOTE: toString() so compiler thinks it isn't a constant, so it won't inline it
-  // {x-version-update-start:google-api-client:current}
   /** Current release version. */
-  public static final String VERSION = "1.30.3".toString();
-  // {x-version-update-end:google-api-client:current}
+  public static final String VERSION = getVersion();
 
   // NOTE: Integer instead of int so compiler thinks it isn't a constant, so it won't inline it
   /**
@@ -89,6 +86,25 @@ public final class GoogleUtils {
       SecurityUtils.loadKeyStore(certTrustStore, keyStoreStream, "notasecret");
     }
     return certTrustStore;
+  }
+
+  private static String getVersion() {
+    String version = GoogleUtils.class.getPackage().getImplementationVersion();
+    // in a non-packaged environment (local), there's no implementation version to read
+    if (version == null) {
+      // fall back to reading from a properties file - note this value is expected to be cached
+      try (InputStream inputStream =
+          GoogleUtils.class.getResourceAsStream("google-api-client.properties")) {
+        if (inputStream != null) {
+          Properties properties = new Properties();
+          properties.load(inputStream);
+          version = properties.getProperty("google-api-client.version");
+        }
+      } catch (IOException e) {
+        // ignore
+      }
+    }
+    return version;
   }
 
   private GoogleUtils() {}

--- a/google-api-client/src/main/properties/com/google/api/client/googleapis/google-api-client.properties
+++ b/google-api-client/src/main/properties/com/google/api/client/googleapis/google-api-client.properties
@@ -1,0 +1,1 @@
+google-api-client.version=${project.version}

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/GoogleUtilsTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/GoogleUtilsTest.java
@@ -56,4 +56,12 @@ public class GoogleUtilsTest extends TestCase {
     assertEquals(30, Integer.parseInt(matcher.group(2)));
     assertEquals(3, Integer.parseInt(matcher.group(3)));
   }
+
+  public void testVersion() {
+    Matcher matcher = GoogleUtils.VERSION_PATTERN.matcher(GoogleUtils.VERSION);
+    assertTrue(matcher.find());
+    assertNotNull(GoogleUtils.MAJOR_VERSION);
+    assertNotNull(GoogleUtils.MINOR_VERSION);
+    assertNotNull(GoogleUtils.BUGFIX_VERSION);
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -419,22 +419,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <configuration>
-          <configLocation>checkstyle.xml</configLocation>
-          <consoleOutput>true</consoleOutput>
-          <suppressionsLocation>${basedir}/../checkstyle-suppressions.xml</suppressionsLocation>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -297,8 +297,9 @@
           </configuration>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>2.6</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -324,6 +325,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
           <version>3.8.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.1.0</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -540,6 +546,54 @@
                     <arg>loopback</arg>
                   </gpgArguments>
                 </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- set project.root-directory property based on where we are -->
+    <profile>
+      <id>root-directory</id>
+      <activation>
+        <file>
+          <exists>checkstyle-suppressions.xml</exists>
+        </file>
+      </activation>
+      <properties>
+        <project.root-directory>.</project.root-directory>
+      </properties>
+    </profile>
+
+    <profile>
+      <!-- Only run checkstyle plugin on Java 8+ (checkstyle artifact only supports Java 8+) -->
+      <id>checkstyle-tests</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-checkstyle-plugin</artifactId>
+            <dependencies>
+              <dependency>
+                <groupId>com.puppycrawl.tools</groupId>
+                <artifactId>checkstyle</artifactId>
+                <version>8.23</version>
+              </dependency>
+            </dependencies>
+            <configuration>
+              <configLocation>checkstyle.xml</configLocation>
+              <consoleOutput>true</consoleOutput>
+              <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>check</goal>
+                </goals>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
This PR allows the GoogleUtils to inspect its own version at start time. If it's running from a package, it can fetch the version from the package manifest's implementation version. If it's not, it can read it from a properties file created at compile time to read the version.

Note:
* This is similar to how gax inspects its own version for the x-goog-api-client header.
* We needed to update the checkstyle plugin to make this pass

