### PR TITLE
fix: use embedded Proguard configuration instead of compile-time annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ To use Gradle, add the following lines to your build.gradle file:
 ```gradle
 repositories {
     mavenCentral()
+    google()
 }
 dependencies {
     compile 'com.google.api-client:google-api-client:1.30.8'

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ To use Gradle, add the following lines to your build.gradle file:
 ```gradle
 repositories {
     mavenCentral()
-    google()
 }
 dependencies {
     compile 'com.google.api-client:google-api-client:1.30.8'

--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -145,23 +145,10 @@
       <artifactId>commons-codec</artifactId>
       <scope>provided</scope>
       <version>1.14</version>
-    </dependency>
+   </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    <dependency>
-      <groupId>androidx.annotation</groupId>
-      <artifactId>annotation</artifactId>
-      <version>1.1.0</version>
-    </dependency>
   </dependencies>
-  
-  <repositories>  
-    <repository>
-      <id>google</id>
-      <name>Google Maven Repository</name>
-      <url>https://maven.google.com/</url>
-    </repository>
-  </repositories>
 </project>

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/GoogleUtils.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/GoogleUtils.java
@@ -14,7 +14,6 @@
 
 package com.google.api.client.googleapis;
 
-import androidx.annotation.Keep;
 import com.google.api.client.util.SecurityUtils;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
@@ -31,7 +30,6 @@ import java.util.regex.Pattern;
  * @since 1.12
  * @author rmistry@google.com (Ravi Mistry)
  */
-@Keep
 public final class GoogleUtils {
 
   /** Current release version. */

--- a/google-api-client/src/main/resources/META-INF/proguard/google-api-client.pro
+++ b/google-api-client/src/main/resources/META-INF/proguard/google-api-client.pro
@@ -1,0 +1,2 @@
+# https://github.com/googleapis/google-api-java-client/issues/1450
+-keep public class com.google.api.client.googleapis.GoogleUtils


### PR DESCRIPTION
R8 provides a mechanism for embedding proguard files, which obviates the need for a compile-time dependency on an Android library in core.

Not well documented but reasonably commonly used.

https://twitter.com/jakewharton/status/1004401938467876865?lang=en
https://github.com/square/retrofit/blob/master/retrofit/src/main/resources/META-INF/proguard/retrofit2.pro

Unfortunately, without a regression test I'm not 100% sure this works, nor am I an Android developer with much confidence, just following the pattern of other libraries :)

Fixes #1487