### PR TITLE
chore: fix synth.metadata

### DIFF
--- a/synth.metadata
+++ b/synth.metadata
@@ -11,7 +11,7 @@
     {
       "git": {
         "name": "synthtool",
-        "remote": "rpc://devrel/cloud/libraries/tools/autosynth",
+        "remote": "https://github.com/googleapis/synthtool.git",
         "sha": "706a38c26db42299845396cdae55db635c38794a"
       }
     },

--- a/synth.metadata
+++ b/synth.metadata
@@ -9,13 +9,6 @@
       }
     },
     {
-      "git": {
-        "name": "synthtool",
-        "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "706a38c26db42299845396cdae55db635c38794a"
-      }
-    },
-    {
       "template": {
         "name": "java_library",
         "origin": "synthtool.gcp",


### PR DESCRIPTION
Fixes #1514

Somehow, the synth.metadata picked up the autosynth git remote which is invalid.