### PR TITLE
replace deprecated apache transport with recommended

### DIFF
--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -150,5 +150,9 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-apache-v2</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/apache/GoogleApacheHttpTransport.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/apache/GoogleApacheHttpTransport.java
@@ -15,7 +15,7 @@
 package com.google.api.client.googleapis.apache;
 
 import com.google.api.client.googleapis.GoogleUtils;
-import com.google.api.client.http.apache.ApacheHttpTransport;
+import com.google.api.client.http.apache.v2.ApacheHttpTransport;
 import com.google.api.client.util.SslUtils;
 import java.io.IOException;
 import java.net.ProxySelector;


### PR DESCRIPTION
Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for context and/or discussion)

Replaced the ApacheHttpTransport based on the recommendation at: https://github.com/googleapis/google-http-java-client/blob/master/google-http-client/src/main/java/com/google/api/client/http/apache/ApacheHttpTransport.java#L77-L78