### PR TITLE
feat: add GoogleApacheHttpTransport that uses the v2 ApacheHttpTransport implementation

### DIFF
--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -150,5 +150,9 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-apache-v2</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/apache/GoogleApacheHttpTransport.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/apache/GoogleApacheHttpTransport.java
@@ -36,7 +36,7 @@ import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
  *
  * @since 1.14
  * @author Yaniv Inbar
- * @deprecated Please use com.google.api.client.googleapis.apache.v2.GoogleApacheHttpTransport
+ * @deprecated Use com.google.api.client.googleapis.apache.v2.GoogleApacheHttpTransport
  */
 @Deprecated
 public final class GoogleApacheHttpTransport {

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/apache/GoogleApacheHttpTransport.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/apache/GoogleApacheHttpTransport.java
@@ -44,7 +44,7 @@ public final class GoogleApacheHttpTransport {
   /**
    * Returns a new instance of {@link ApacheHttpTransport} that uses
    * {@link GoogleUtils#getCertificateTrustStore()} for the trusted certificates.
-   * @deprecated Please use com.google.api.client.googleapis.apache.v2.GoogleApacheHttpTransport.newTrustedTransport()
+   * @deprecated Use com.google.api.client.googleapis.apache.v2.GoogleApacheHttpTransport.newTrustedTransport()
    */
   public static ApacheHttpTransport newTrustedTransport() throws GeneralSecurityException,
       IOException {

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/apache/package-info.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/apache/package-info.java
@@ -13,7 +13,7 @@
  */
 
 /**
- * Google API's support based on the Apache HTTP Client.
+ * Google APIs support based on the Apache HTTP Client.
  *
  * @since 1.14
  * @author Yaniv Inbar

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/apache/v2/GoogleApacheHttpTransport.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/apache/v2/GoogleApacheHttpTransport.java
@@ -44,13 +44,6 @@ public final class GoogleApacheHttpTransport {
    */
   public static ApacheHttpTransport newTrustedTransport() throws GeneralSecurityException,
       IOException {
-    // Set socket buffer sizes to 8192
-    SocketConfig socketConfig =
-        SocketConfig.custom()
-            .setRcvBufSize(8192)
-            .setSndBufSize(8192)
-            .build();
-
     PoolingHttpClientConnectionManager connectionManager =
         new PoolingHttpClientConnectionManager(-1, TimeUnit.MILLISECONDS);
 
@@ -66,7 +59,6 @@ public final class GoogleApacheHttpTransport {
     HttpClient client = HttpClientBuilder.create()
         .useSystemProperties()
         .setSSLSocketFactory(socketFactory)
-        .setDefaultSocketConfig(socketConfig)
         .setMaxConnTotal(200)
         .setMaxConnPerRoute(20)
         .setRoutePlanner(new SystemDefaultRoutePlanner(ProxySelector.getDefault()))

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/apache/v2/GoogleApacheHttpTransport.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/apache/v2/GoogleApacheHttpTransport.java
@@ -35,7 +35,6 @@ import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
  * Utilities for Google APIs based on {@link ApacheHttpTransport}.
  *
  * @since 1.31
- * @author Yaniv Inbar
  */
 public final class GoogleApacheHttpTransport {
 

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/apache/v2/GoogleApacheHttpTransport.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/apache/v2/GoogleApacheHttpTransport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Google Inc.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -12,10 +12,10 @@
  * the License.
  */
 
-package com.google.api.client.googleapis.apache;
+package com.google.api.client.googleapis.apache.v2;
 
 import com.google.api.client.googleapis.GoogleUtils;
-import com.google.api.client.http.apache.ApacheHttpTransport;
+import com.google.api.client.http.apache.v2.ApacheHttpTransport;
 import com.google.api.client.util.SslUtils;
 import java.io.IOException;
 import java.net.ProxySelector;
@@ -34,17 +34,14 @@ import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
 /**
  * Utilities for Google APIs based on {@link ApacheHttpTransport}.
  *
- * @since 1.14
+ * @since 1.31
  * @author Yaniv Inbar
- * @deprecated Please use com.google.api.client.googleapis.apache.v2.GoogleApacheHttpTransport
  */
-@Deprecated
 public final class GoogleApacheHttpTransport {
 
   /**
    * Returns a new instance of {@link ApacheHttpTransport} that uses
    * {@link GoogleUtils#getCertificateTrustStore()} for the trusted certificates.
-   * @deprecated Please use com.google.api.client.googleapis.apache.v2.GoogleApacheHttpTransport.newTrustedTransport()
    */
   public static ApacheHttpTransport newTrustedTransport() throws GeneralSecurityException,
       IOException {

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/apache/v2/package-info.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/apache/v2/package-info.java
@@ -13,7 +13,7 @@
  */
 
 /**
- * Google API's support based on the Apache HTTP Client.
+ * Google APIs support based on the Apache HTTP Client.
  *
  * @since 1.31
  */

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/apache/v2/package-info.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/apache/v2/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Google API's support based on the Apache HTTP Client.
+ *
+ * @since 1.31
+ */
+
+package com.google.api.client.googleapis.apache.v2;
+


### PR DESCRIPTION
* Introduces a separate GoogleApacheHttpTransport that return the v2 ApacheHttpTransport implementation.
* Deprecates the original GoogleApacheHttpTransport in favor of this one.
