### PR TITLE
fix: socketfactory not registered for apache

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/apache/v2/GoogleApacheHttpTransport.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/apache/v2/GoogleApacheHttpTransport.java
@@ -21,6 +21,7 @@ import com.google.api.client.googleapis.util.Utils;
 import com.google.api.client.http.apache.v2.ApacheHttpTransport;
 import com.google.api.client.util.Beta;
 import com.google.api.client.util.SslUtils;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.net.ProxySelector;
 import java.security.GeneralSecurityException;
@@ -32,6 +33,7 @@ import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.LayeredConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
@@ -67,37 +69,10 @@ public final class GoogleApacheHttpTransport {
   @Beta
   public static ApacheHttpTransport newTrustedTransport(MtlsProvider mtlsProvider)
       throws GeneralSecurityException, IOException {
-    KeyStore mtlsKeyStore = null;
-    String mtlsKeyStorePassword = null;
-    if (mtlsProvider.useMtlsClientCertificate()) {
-      mtlsKeyStore = mtlsProvider.getKeyStore();
-      mtlsKeyStorePassword = mtlsProvider.getKeyStorePassword();
-    }
-
-    // Use the included trust store
-    KeyStore trustStore = GoogleUtils.getCertificateTrustStore();
-    SSLContext sslContext = SslUtils.getTlsSslContext();
-
-    boolean isMtls = false;
-    if (mtlsKeyStore != null && mtlsKeyStorePassword != null) {
-      isMtls = true;
-      SslUtils.initSslContext(
-          sslContext,
-          trustStore,
-          SslUtils.getPkixTrustManagerFactory(),
-          mtlsKeyStore,
-          mtlsKeyStorePassword,
-          SslUtils.getDefaultKeyManagerFactory());
-    } else {
-      SslUtils.initSslContext(sslContext, trustStore, SslUtils.getPkixTrustManagerFactory());
-    }
-    LayeredConnectionSocketFactory socketFactory = new SSLConnectionSocketFactory(sslContext);
-
-    Registry<ConnectionSocketFactory> socketFactoryRegistry =
-        RegistryBuilder.<ConnectionSocketFactory>create().register("https", socketFactory).build();
+    SocketFactoryRegistryHandler handler = new SocketFactoryRegistryHandler(mtlsProvider);
     PoolingHttpClientConnectionManager connectionManager =
         new PoolingHttpClientConnectionManager(
-            socketFactoryRegistry, null, null, null, -1, TimeUnit.MILLISECONDS);
+            handler.getSocketFactoryRegistry(), null, null, null, -1, TimeUnit.MILLISECONDS);
 
     // Disable the stale connection check (previously configured in the
     // HttpConnectionParams
@@ -106,7 +81,6 @@ public final class GoogleApacheHttpTransport {
     HttpClient client =
         HttpClientBuilder.create()
             .useSystemProperties()
-            .setSSLSocketFactory(socketFactory)
             .setMaxConnTotal(200)
             .setMaxConnPerRoute(20)
             .setRoutePlanner(new SystemDefaultRoutePlanner(ProxySelector.getDefault()))
@@ -114,7 +88,56 @@ public final class GoogleApacheHttpTransport {
             .disableRedirectHandling()
             .disableAutomaticRetries()
             .build();
-    return new ApacheHttpTransport(client, isMtls);
+    return new ApacheHttpTransport(client, handler.isMtls());
+  }
+
+  @VisibleForTesting
+  static class SocketFactoryRegistryHandler {
+    private final Registry<ConnectionSocketFactory> socketFactoryRegistry;
+    private final boolean isMtls;
+
+    public SocketFactoryRegistryHandler(MtlsProvider mtlsProvider)
+        throws GeneralSecurityException, IOException {
+      KeyStore mtlsKeyStore = null;
+      String mtlsKeyStorePassword = null;
+      if (mtlsProvider.useMtlsClientCertificate()) {
+        mtlsKeyStore = mtlsProvider.getKeyStore();
+        mtlsKeyStorePassword = mtlsProvider.getKeyStorePassword();
+      }
+
+      // Use the included trust store
+      KeyStore trustStore = GoogleUtils.getCertificateTrustStore();
+      SSLContext sslContext = SslUtils.getTlsSslContext();
+
+      if (mtlsKeyStore != null && mtlsKeyStorePassword != null) {
+        this.isMtls = true;
+        SslUtils.initSslContext(
+            sslContext,
+            trustStore,
+            SslUtils.getPkixTrustManagerFactory(),
+            mtlsKeyStore,
+            mtlsKeyStorePassword,
+            SslUtils.getDefaultKeyManagerFactory());
+      } else {
+        this.isMtls = false;
+        SslUtils.initSslContext(sslContext, trustStore, SslUtils.getPkixTrustManagerFactory());
+      }
+      LayeredConnectionSocketFactory socketFactory = new SSLConnectionSocketFactory(sslContext);
+
+      this.socketFactoryRegistry =
+          RegistryBuilder.<ConnectionSocketFactory>create()
+              .register("http", PlainConnectionSocketFactory.getSocketFactory())
+              .register("https", socketFactory)
+              .build();
+    }
+
+    public Registry<ConnectionSocketFactory> getSocketFactoryRegistry() {
+      return this.socketFactoryRegistry;
+    }
+
+    public boolean isMtls() {
+      return this.isMtls;
+    }
   }
 
   private GoogleApacheHttpTransport() {}

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/apache/v2/GoogleApacheHttpTransportTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/apache/v2/GoogleApacheHttpTransportTest.java
@@ -14,16 +14,30 @@
 
 package com.google.api.client.googleapis.apache.v2;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.google.api.client.googleapis.apache.v2.GoogleApacheHttpTransport.SocketFactoryRegistryHandler;
 import com.google.api.client.googleapis.mtls.MtlsProvider;
 import com.google.api.client.googleapis.mtls.MtlsTransportBaseTest;
 import com.google.api.client.http.HttpTransport;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import org.junit.Test;
 
 public class GoogleApacheHttpTransportTest extends MtlsTransportBaseTest {
   @Override
   protected HttpTransport buildTrustedTransport(MtlsProvider mtlsProvider)
       throws GeneralSecurityException, IOException {
     return GoogleApacheHttpTransport.newTrustedTransport(mtlsProvider);
+  }
+
+  @Test
+  public void socketFactoryRegistryHandlerTest() throws GeneralSecurityException, IOException {
+    MtlsProvider mtlsProvider = new TestMtlsProvider(true, createTestMtlsKeyStore(), "", false);
+    SocketFactoryRegistryHandler handler = new SocketFactoryRegistryHandler(mtlsProvider);
+    assertNotNull(handler.getSocketFactoryRegistry().lookup("http"));
+    assertNotNull(handler.getSocketFactoryRegistry().lookup("https"));
+    assertTrue(handler.isMtls());
   }
 }

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/mtls/MtlsTransportBaseTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/mtls/MtlsTransportBaseTest.java
@@ -41,7 +41,7 @@ public abstract class MtlsTransportBaseTest {
     private String keyStorePassword;
     private boolean throwExceptionForGetKeyStore;
 
-    TestMtlsProvider(
+    public TestMtlsProvider(
         boolean useClientCertificate,
         KeyStore keystore,
         String keyStorePassword,


### PR DESCRIPTION
For `GoogleApacheHttpTransport`, `socketFactory` has to be registered for https, and provided to `connectionManager`. This PR does the following:

- register socket factory for `http` and `https`, and pass to connection manager ([reference](https://github.com/mydevotion/httpclient/blob/master/httpclient/src/main/java/org/apache/http/impl/conn/PoolingHttpClientConnectionManager.java#L109))
- removed `.setSSLSocketFactory(socketFactory)` from the chain of calls after `HttpClientBuilder.create()`, since it will be overwritten by `.setConnectionManager(connectionManager)`