### PR TITLE
ci: linkage monitor CI update to stop using .kokoro/linkage-monitor.sh

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,8 +74,11 @@ jobs:
       with:
         java-version: 8
     - run: java -version
-    - run: .kokoro/install_dependencies.sh
-    - run: .kokoro/linkage-monitor.sh
+    - name: Install artifacts to local Maven repository
+      run: .kokoro/build.sh
+      shell: bash
+    - name: Validate dependencies with regard to com.google.cloud:libraries-bom (latest release)
+      uses: GoogleCloudPlatform/cloud-opensource-java/linkage-monitor@v1-linkagemonitor
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,6 +74,7 @@ jobs:
       with:
         java-version: 8
     - run: java -version
+    - run: .kokoro/install_dependencies.sh
     - name: Install artifacts to local Maven repository
       run: .kokoro/build.sh
       shell: bash


### PR DESCRIPTION
For https://github.com/googleapis/google-api-java-client/pull/1717 ("ci / linkage-monitor" is failing), this change by synthtool expects the ci.yaml
to use the Linkage Monitor GitHub Actions and it deletes .kokoro/linkage-monitor.sh.
However this repository excludes ci.yaml from being managed by synthtool. Therefore we need to manually maintain ci.yaml to stop using linkage-monitor.sh.

---

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-api-java-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️
