### PR TITLE
ci: removing Kokoro from required checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -37,10 +37,6 @@ branchProtectionRules:
     - "linkage-monitor"
     - "lint"
     - "clirr"
-    - "Kokoro - Test: Binary Compatibility"
-    - "Kokoro - Test: Java 11"
-    - "Kokoro - Test: Java 7"
-    - "Kokoro - Test: Java 8"
     - "cla/google"
 
 # List of explicit permissions to add (additive only)


### PR DESCRIPTION
- Kokoro unit tests for Java 7 - Java 11 are now performed by GitHub Actions:units (7) - units (11)
- CLIRR takes over "Kokoro: Test: Binary Compatibility".

Created corresponding cl/360270976 to stop these Kokoro jobs. Note that this PR needs to come first and and reflect the change to the repository settings, before I submit the CL.

@chingor13 @stephaniewang526 

