### PR TITLE
fix: update GoogleJsonError object to accomodate all fields in Invalid parameter exception

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/json/GoogleJsonError.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/json/GoogleJsonError.java
@@ -183,6 +183,59 @@ public class GoogleJsonError extends GenericJson {
     }
   }
 
+  public static class Details {
+    @Key("@type")
+    private String type;
+
+    @Key private String detail;
+    @Key private List<ParameterViolations> parameterViolations;
+
+    public String getType() {
+      return type;
+    }
+
+    public void setType(String type) {
+      this.type = type;
+    }
+
+    public String getDetail() {
+      return detail;
+    }
+
+    public void setDetail(String detail) {
+      this.detail = detail;
+    }
+
+    public List<ParameterViolations> getParameterViolations() {
+      return parameterViolations;
+    }
+
+    public void setParameterViolations(List<ParameterViolations> parameterViolations) {
+      this.parameterViolations = parameterViolations;
+    }
+  }
+
+  public static class ParameterViolations {
+    @Key private String parameter;
+    @Key private String description;
+
+    public String getDescription() {
+      return description;
+    }
+
+    public void setDescription(String description) {
+      this.description = description;
+    }
+
+    public String getParameter() {
+      return parameter;
+    }
+
+    public void setParameter(String parameter) {
+      this.parameter = parameter;
+    }
+  }
+
   /** List of detailed errors or {@code null} for none. */
   @Key private List<ErrorInfo> errors;
 
@@ -191,6 +244,9 @@ public class GoogleJsonError extends GenericJson {
 
   /** Human-readable explanation of the error or {@code null} for none. */
   @Key private String message;
+
+  /** Lists type and parameterViolation details of an Exception */
+  @Key private List<Details> details;
 
   /**
    * Returns the list of detailed errors or {@code null} for none.
@@ -244,6 +300,14 @@ public class GoogleJsonError extends GenericJson {
    */
   public final void setMessage(String message) {
     this.message = message;
+  }
+
+  public List<Details> getDetails() {
+    return details;
+  }
+
+  public void setDetails(List<Details> details) {
+    this.details = details;
   }
 
   @Override

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/json/GoogleJsonError.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/json/GoogleJsonError.java
@@ -21,6 +21,7 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.util.Data;
 import com.google.api.client.util.Key;
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -210,8 +211,13 @@ public class GoogleJsonError extends GenericJson {
       return parameterViolations;
     }
 
+    /**
+     * Sets parameterViolations list as immutable to prevent exposing mutable state.
+     *
+     * @param parameterViolations
+     */
     public void setParameterViolations(List<ParameterViolations> parameterViolations) {
-      this.parameterViolations = parameterViolations;
+      this.parameterViolations = ImmutableList.copyOf(parameterViolations);
     }
   }
 
@@ -258,12 +264,13 @@ public class GoogleJsonError extends GenericJson {
   }
 
   /**
-   * Sets the list of detailed errors or {@code null} for none.
+   * Sets the list of detailed errors or {@code null} for none. Sets the list of detailed errors as
+   * immutable to prevent exposing mutable state.
    *
    * @since 1.8
    */
   public final void setErrors(List<ErrorInfo> errors) {
-    this.errors = errors;
+    this.errors = ImmutableList.copyOf(errors);
   }
 
   /**
@@ -306,8 +313,14 @@ public class GoogleJsonError extends GenericJson {
     return details;
   }
 
+  /**
+   * Sets the list of invalid parameter error details as immutable to prevent exposing mutable
+   * state.
+   *
+   * @param details
+   */
   public void setDetails(List<Details> details) {
-    this.details = details;
+    this.details = ImmutableList.copyOf(details);
   }
 
   @Override

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/json/GoogleJsonErrorTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/json/GoogleJsonErrorTest.java
@@ -27,6 +27,7 @@ import com.google.api.client.testing.http.HttpTesting;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import java.io.InputStream;
 import junit.framework.TestCase;
 
 /**
@@ -51,7 +52,8 @@ public class GoogleJsonErrorTest extends TestCase {
   public void test_json() throws Exception {
     JsonParser parser = FACTORY.createJsonParser(ERROR);
     parser.nextToken();
-    GoogleJsonError e = parser.parse(GoogleJsonError.class);
+    GoogleJsonError e = parser.parse(
+        GoogleJsonError.class);
     assertEquals(ERROR, FACTORY.toString(e));
   }
 
@@ -70,6 +72,10 @@ public class GoogleJsonErrorTest extends TestCase {
               .setStatusCode(HttpStatusCodes.STATUS_CODE_FORBIDDEN);
     }
 
+    ErrorTransport(MockLowLevelHttpResponse mockLowLevelHttpResponse) {
+      response = mockLowLevelHttpResponse;
+    }
+
     @Override
     public LowLevelHttpRequest buildRequest(String name, String url) {
       return new MockLowLevelHttpRequest(url).setResponse(response);
@@ -82,7 +88,40 @@ public class GoogleJsonErrorTest extends TestCase {
         transport.createRequestFactory().buildGetRequest(HttpTesting.SIMPLE_GENERIC_URL);
     request.setThrowExceptionOnExecuteError(false);
     HttpResponse response = request.execute();
-    GoogleJsonError errorResponse = GoogleJsonError.parse(FACTORY, response);
+    GoogleJsonError errorResponse = GoogleJsonError
+        .parse(FACTORY, response);
     assertEquals(ERROR, FACTORY.toString(errorResponse));
+  }
+
+  public void testParse_withDetails() throws Exception {
+    String DETAILS_ERROR =
+        "{"
+            + "\"code\":400,"
+            + "\"details\":[{"
+            + "\"@type\":\"type.googleapis.com/google.dataflow.v1beta3.InvalidTemplateParameters\","
+            + "\"parameterViolations\":[{"
+            + "\"description\":\"Parameter didn't match regex '^[0-9a-zA-Z_]+$'\","
+            + "\"parameter\":\"safeBrowsingApiKey\""
+            + "}]},{"
+            + "\"@type\":\"type.googleapis.com/google.rpc.DebugInfo\","
+            + "\"detail\":\"test detail\"}],"
+            + "\"message\":\"The template parameters are invalid.\","
+            + "\"status\":\"INVALID_ARGUMENT\""
+            + "}";
+    InputStream errorContent = GoogleJsonErrorTest.class.getResourceAsStream("error.json");
+    HttpTransport transport =
+        new ErrorTransport(
+            new MockLowLevelHttpResponse()
+                .setContent(errorContent)
+                .setContentType(Json.MEDIA_TYPE)
+                .setStatusCode(HttpStatusCodes.STATUS_CODE_FORBIDDEN));
+    HttpRequest request =
+        transport.createRequestFactory().buildGetRequest(HttpTesting.SIMPLE_GENERIC_URL);
+    request.setThrowExceptionOnExecuteError(false);
+    HttpResponse response = request.execute();
+    GoogleJsonError errorResponse = GoogleJsonError
+        .parse(FACTORY, response);
+    assertEquals(DETAILS_ERROR, FACTORY.toString(errorResponse));
+    assertNotNull(errorResponse.getDetails());
   }
 }

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/json/GoogleJsonErrorTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/json/GoogleJsonErrorTest.java
@@ -31,7 +31,7 @@ import java.io.InputStream;
 import junit.framework.TestCase;
 
 /**
- * Tests {@link GoogleJsonError}.
+ * Tests {@link com.google.api.client.googleapis.json.GoogleJsonError}.
  *
  * @author Yaniv Inbar
  */
@@ -52,8 +52,8 @@ public class GoogleJsonErrorTest extends TestCase {
   public void test_json() throws Exception {
     JsonParser parser = FACTORY.createJsonParser(ERROR);
     parser.nextToken();
-    GoogleJsonError e = parser.parse(
-        GoogleJsonError.class);
+    com.google.api.client.googleapis.json.GoogleJsonError e =
+        parser.parse(com.google.api.client.googleapis.json.GoogleJsonError.class);
     assertEquals(ERROR, FACTORY.toString(e));
   }
 
@@ -88,8 +88,8 @@ public class GoogleJsonErrorTest extends TestCase {
         transport.createRequestFactory().buildGetRequest(HttpTesting.SIMPLE_GENERIC_URL);
     request.setThrowExceptionOnExecuteError(false);
     HttpResponse response = request.execute();
-    GoogleJsonError errorResponse = GoogleJsonError
-        .parse(FACTORY, response);
+    com.google.api.client.googleapis.json.GoogleJsonError errorResponse =
+        com.google.api.client.googleapis.json.GoogleJsonError.parse(FACTORY, response);
     assertEquals(ERROR, FACTORY.toString(errorResponse));
   }
 
@@ -119,8 +119,8 @@ public class GoogleJsonErrorTest extends TestCase {
         transport.createRequestFactory().buildGetRequest(HttpTesting.SIMPLE_GENERIC_URL);
     request.setThrowExceptionOnExecuteError(false);
     HttpResponse response = request.execute();
-    GoogleJsonError errorResponse = GoogleJsonError
-        .parse(FACTORY, response);
+    com.google.api.client.googleapis.json.GoogleJsonError errorResponse =
+        com.google.api.client.googleapis.json.GoogleJsonError.parse(FACTORY, response);
     assertEquals(DETAILS_ERROR, FACTORY.toString(errorResponse));
     assertNotNull(errorResponse.getDetails());
   }

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/json/GoogleJsonErrorTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/json/GoogleJsonErrorTest.java
@@ -121,6 +121,7 @@ public class GoogleJsonErrorTest extends TestCase {
     HttpResponse response = request.execute();
     com.google.api.client.googleapis.json.GoogleJsonError errorResponse =
         com.google.api.client.googleapis.json.GoogleJsonError.parse(FACTORY, response);
+
     assertEquals(DETAILS_ERROR, FACTORY.toString(errorResponse));
     assertNotNull(errorResponse.getDetails());
   }

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/json/GoogleJsonResponseExceptionTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/json/GoogleJsonResponseExceptionTest.java
@@ -40,7 +40,8 @@ public class GoogleJsonResponseExceptionTest extends TestCase {
     request.setThrowExceptionOnExecuteError(false);
     HttpResponse response = request.execute();
     GoogleJsonResponseException ge =
-        GoogleJsonResponseException.from(GoogleJsonErrorTest.FACTORY, response);
+        GoogleJsonResponseException.from(
+            com.google.api.client.googleapis.json.GoogleJsonErrorTest.FACTORY, response);
     assertNull(ge.getDetails());
     assertTrue(ge.getMessage().startsWith("200"));
   }
@@ -52,9 +53,12 @@ public class GoogleJsonResponseExceptionTest extends TestCase {
     request.setThrowExceptionOnExecuteError(false);
     HttpResponse response = request.execute();
     GoogleJsonResponseException ge =
-        GoogleJsonResponseException.from(GoogleJsonErrorTest.FACTORY, response);
+        GoogleJsonResponseException.from(
+            com.google.api.client.googleapis.json.GoogleJsonErrorTest.FACTORY, response);
     assertEquals(
-        GoogleJsonErrorTest.ERROR, GoogleJsonErrorTest.FACTORY.toString(ge.getDetails()));
+        com.google.api.client.googleapis.json.GoogleJsonErrorTest.ERROR,
+        com.google.api.client.googleapis.json.GoogleJsonErrorTest.FACTORY.toString(
+            ge.getDetails()));
     assertTrue(ge.getMessage().startsWith("403"));
   }
 
@@ -65,7 +69,8 @@ public class GoogleJsonResponseExceptionTest extends TestCase {
     request.setThrowExceptionOnExecuteError(false);
     HttpResponse response = request.execute();
     GoogleJsonResponseException ge =
-        GoogleJsonResponseException.from(GoogleJsonErrorTest.FACTORY, response);
+        GoogleJsonResponseException.from(
+            com.google.api.client.googleapis.json.GoogleJsonErrorTest.FACTORY, response);
     assertNull(ge.getDetails());
     assertTrue(ge.getMessage().startsWith("403"));
   }
@@ -77,7 +82,8 @@ public class GoogleJsonResponseExceptionTest extends TestCase {
     request.setThrowExceptionOnExecuteError(false);
     HttpResponse response = request.execute();
     GoogleJsonResponseException ge =
-        GoogleJsonResponseException.from(GoogleJsonErrorTest.FACTORY, response);
+        GoogleJsonResponseException.from(
+            com.google.api.client.googleapis.json.GoogleJsonErrorTest.FACTORY, response);
     assertNull(ge.getDetails());
     assertTrue(ge.getMessage().startsWith("403"));
   }
@@ -89,7 +95,8 @@ public class GoogleJsonResponseExceptionTest extends TestCase {
     request.setThrowExceptionOnExecuteError(false);
     HttpResponse response = request.execute();
     GoogleJsonResponseException ge =
-        GoogleJsonResponseException.from(GoogleJsonErrorTest.FACTORY, response);
+        GoogleJsonResponseException.from(
+            com.google.api.client.googleapis.json.GoogleJsonErrorTest.FACTORY, response);
     assertNull(ge.getDetails());
     assertTrue(ge.getMessage().startsWith("403"));
     assertTrue(ge.getMessage().contains("<foo>"));
@@ -102,7 +109,8 @@ public class GoogleJsonResponseExceptionTest extends TestCase {
     request.setThrowExceptionOnExecuteError(false);
     HttpResponse response = request.execute();
     GoogleJsonResponseException ge =
-        GoogleJsonResponseException.from(GoogleJsonErrorTest.FACTORY, response);
+        GoogleJsonResponseException.from(
+            com.google.api.client.googleapis.json.GoogleJsonErrorTest.FACTORY, response);
     assertNull(ge.getDetails());
     assertTrue(ge.getMessage().startsWith("403"));
   }
@@ -114,7 +122,8 @@ public class GoogleJsonResponseExceptionTest extends TestCase {
     request.setThrowExceptionOnExecuteError(false);
     HttpResponse response = request.execute();
     GoogleJsonResponseException ge =
-        GoogleJsonResponseException.from(GoogleJsonErrorTest.FACTORY, response);
+        GoogleJsonResponseException.from(
+            com.google.api.client.googleapis.json.GoogleJsonErrorTest.FACTORY, response);
     assertNull(ge.getDetails());
     assertTrue(ge.getMessage().startsWith("403"));
   }
@@ -129,7 +138,8 @@ public class GoogleJsonResponseExceptionTest extends TestCase {
     request.setThrowExceptionOnExecuteError(false);
     HttpResponse response = request.execute();
     GoogleJsonResponseException ge =
-        GoogleJsonResponseException.from(GoogleJsonErrorTest.FACTORY, response);
+        GoogleJsonResponseException.from(
+            com.google.api.client.googleapis.json.GoogleJsonErrorTest.FACTORY, response);
     assertNotNull(ge.getDetails());
     assertEquals("invalid_token", ge.getDetails().getMessage());
     assertTrue(ge.getMessage().contains("403"));
@@ -145,7 +155,8 @@ public class GoogleJsonResponseExceptionTest extends TestCase {
     request.setThrowExceptionOnExecuteError(false);
     HttpResponse response = request.execute();
     GoogleJsonResponseException ge =
-        GoogleJsonResponseException.from(GoogleJsonErrorTest.FACTORY, response);
+        GoogleJsonResponseException.from(
+            com.google.api.client.googleapis.json.GoogleJsonErrorTest.FACTORY, response);
     assertNull(ge.getDetails());
     assertTrue(ge.getMessage().contains("403"));
     assertTrue(ge.getMessage().contains("invalid_token"));
@@ -159,7 +170,8 @@ public class GoogleJsonResponseExceptionTest extends TestCase {
     request.setThrowExceptionOnExecuteError(false);
     HttpResponse response = request.execute();
     GoogleJsonResponseException ge =
-        GoogleJsonResponseException.from(GoogleJsonErrorTest.FACTORY, response);
+        GoogleJsonResponseException.from(
+            com.google.api.client.googleapis.json.GoogleJsonErrorTest.FACTORY, response);
     assertNull(ge.getDetails());
     assertTrue(ge.getMessage().startsWith("403"));
   }
@@ -179,7 +191,9 @@ public class GoogleJsonResponseExceptionTest extends TestCase {
             + "\"message\":\"The template parameters are invalid.\","
             + "\"status\":\"INVALID_ARGUMENT\""
             + "}";
-    InputStream errorContent = GoogleJsonErrorTest.class.getResourceAsStream("error.json");
+    InputStream errorContent =
+        com.google.api.client.googleapis.json.GoogleJsonErrorTest.class.getResourceAsStream(
+            "error.json");
     HttpTransport transport =
         new ErrorTransport(
             new MockLowLevelHttpResponse()
@@ -191,7 +205,8 @@ public class GoogleJsonResponseExceptionTest extends TestCase {
     request.setThrowExceptionOnExecuteError(false);
     HttpResponse response = request.execute();
     GoogleJsonResponseException ge =
-        GoogleJsonResponseException.from(GoogleJsonErrorTest.FACTORY, response);
+        GoogleJsonResponseException.from(
+            com.google.api.client.googleapis.json.GoogleJsonErrorTest.FACTORY, response);
     assertNotNull(ge.getDetails().getDetails());
   }
 }

--- a/google-api-client/src/test/resources/com/google/api/client/googleapis/json/error.json
+++ b/google-api-client/src/test/resources/com/google/api/client/googleapis/json/error.json
@@ -1,0 +1,23 @@
+{
+  "error": {
+    "code": 400,
+    "message": "The template parameters are invalid.",
+    "status": "INVALID_ARGUMENT",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.dataflow.v1beta3.InvalidTemplateParameters",
+        "parameterViolations": [
+          {
+            "parameter": "safeBrowsingApiKey",
+            "description": "Parameter didn't match regex '^[0-9a-zA-Z_]+$'"
+          }
+        ]
+      },
+      {
+        "@type": "type.googleapis.com/google.rpc.DebugInfo",
+        "detail": "test detail"
+      }
+    ]
+  }
+}
+


### PR DESCRIPTION
Fixes b/185405327

Invalid parameter error message does not contain details about which parameter is the invalid one. These fields have been added to GoogleJsonError object.