### PR TITLE
fix: bring comment up to date with code

### DIFF
--- a/google-api-client-appengine/pom.xml
+++ b/google-api-client-appengine/pom.xml
@@ -71,7 +71,7 @@
           </execution>
         </executions>
       </plugin>
-      <!--App Engine uses Java 6 and above-->
+      <!--App Engine uses Java 7 and above-->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>


### PR DESCRIPTION
@chingor13 I think there are still some old projects using Java 7 on app engine, but Java 6 should be gone.
