### PR TITLE
ci: uninstalling linkage-monitor

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,20 +62,6 @@ jobs:
     - run: java -version
     - run: .kokoro/install_dependencies.sh
     - run: .kokoro/dependencies.sh
-  linkage-monitor:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
-      with:
-        java-version: 8
-    - run: java -version
-    - run: .kokoro/install_dependencies.sh
-    - name: Install artifacts to local Maven repository
-      run: .kokoro/build.sh
-      shell: bash
-    - name: Validate dependencies with regard to com.google.cloud:libraries-bom (latest release)
-      uses: GoogleCloudPlatform/cloud-opensource-java/linkage-monitor@v1-linkagemonitor
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Removing linkage-monitor check from GitHub Check. It's not a required check.