### PR TITLE
feat: deprecate OOB auth flow in GooglePromptReceiver

### DIFF
--- a/google-api-client-java6/src/main/java/com/google/api/client/googleapis/extensions/java6/auth/oauth2/GooglePromptReceiver.java
+++ b/google-api-client-java6/src/main/java/com/google/api/client/googleapis/extensions/java6/auth/oauth2/GooglePromptReceiver.java
@@ -27,6 +27,7 @@ import java.io.IOException;
  * @since 1.11
  * @author Yaniv Inbar
  */
+@Deprecated
 public class GooglePromptReceiver extends AbstractPromptReceiver {
 
   @Override


### PR DESCRIPTION
OAuth [out-of-band](https://developers.google.com/identity/protocols/oauth2/native-app#manual-copypaste) (OOB) is a legacy flow developed to support native clients which do not have a redirect URI like web apps to accept the credentials after a user approves an OAuth consent request. The OOB flow poses a remote phishing risk and clients must migrate to an alternative method to protect against this vulnerability. New clients will be unable to use this flow starting on Feb 28, 2022.
[More details.](https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html)