### PR TITLE
deps: revert protobuf to 3.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -499,7 +499,7 @@
     <project.oauth.version>1.33.2</project.oauth.version>
     <project.jsr305.version>3.0.2</project.jsr305.version>
     <project.gson.version>2.8.6</project.gson.version>
-    <project.protobuf-java.version>3.20.0</project.protobuf-java.version>
+    <project.protobuf-java.version>3.19.4</project.protobuf-java.version>
     <project.guava.version>31.1-jre</project.guava.version>
     <project.appengine.version>2.0.4</project.appengine.version>
     <project.xpp3.version>1.1.4c</project.xpp3.version>


### PR DESCRIPTION
Reverting update dependency com.google.protobuf:protobuf-java to v3.20.0 (#2029)

This reverts commit b36c162de0a1df8a0a5e4058037dca3db2470883.

This version aligns other dependencies for Cloud client libraries, just in case we need to release this repository soon.