### PR TITLE
feat: next release from main branch is 1.35.0

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -10,3 +10,7 @@ branches:
     handleGHRelease: true
     releaseType: java-backport
     branch: 1.32.x
+  - bumpMinorPreMajor: true
+    handleGHRelease: true
+    releaseType: java-backport
+    branch: 1.34.x

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -45,6 +45,20 @@ branchProtectionRules:
       - lint
       - clirr
       - cla/google
+  - pattern: 1.34.x
+    isAdminEnforced: true
+    requiredApprovingReviewCount: 1
+    requiresCodeOwnerReviews: true
+    requiresStrictStatusChecks: false
+    requiredStatusCheckContexts:
+      - units (8)
+      - units (11)
+      - windows
+      - dependencies (8)
+      - dependencies (11)
+      - lint
+      - clirr
+      - cla/google
 permissionRules:
   - team: yoshi-admins
     permission: admin


### PR DESCRIPTION
enable releases

go/backport-releases:

```
$ release-brancher create-pull-request \
  --branch-name="1.34.x" \
  --target-tag="v1.34.0" \
  --repo="googleapis/google-api-java-client" \
  --pull-request-title="feat: next release from main branch is 1.35.0" \
  --release-type=java-backport --github-token ${GITHUB_TOKEN}
```