### PR TITLE
deps: google-http-client to a version that depends on appengine-api to 1.9.X

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -493,7 +493,7 @@
   </build>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.http.version>1.41.7</project.http.version>
+    <project.http.version>1.41.8</project.http.version>
     <project.httpcore.version>4.4.15</project.httpcore.version>
     <project.httpclient.version>4.5.13</project.httpclient.version>
     <project.oauth.version>1.33.2</project.oauth.version>


### PR DESCRIPTION
deps: upgrade google-http-client 1.41.8 (which uses appengine-api 1.9.X)
deps: downgrade appengine-api to 1.9.X