### PR TITLE
chore: set Java header during native image runtime

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
@@ -37,6 +37,7 @@ import com.google.api.client.http.HttpResponseInterceptor;
 import com.google.api.client.http.UriTemplate;
 import com.google.api.client.util.GenericData;
 import com.google.api.client.util.Preconditions;
+import com.google.common.base.Joiner;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -164,6 +165,16 @@ public abstract class AbstractGoogleClientRequest<T> extends GenericData {
     }
 
     public String toString() {
+      // When running the application as a native image, append `-graalvm` to the
+      // version.
+      String imageCode = System.getProperty("org.graalvm.nativeimage.imagecode");
+      if (imageCode != null && imageCode.equals("runtime")){
+        String[] tokens = versionString.split(" ");
+        if (tokens.length > 0 && tokens[0].startsWith("gl-java")) {
+          tokens[0] += "-graalvm";
+          return Joiner.on(" ").join(tokens);
+        }
+      }
       return versionString;
     }
 

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequestTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequestTest.java
@@ -261,6 +261,14 @@ public class AbstractGoogleClientRequestTest extends TestCase {
     assertTrue("Api version should contain the os version", version.matches(".* my-os/1.2.3"));
   }
 
+  public void testSetsApiClientHeader_NativeImage() throws IOException {
+    System.setProperty("org.graalvm.nativeimage.imagecode", "runtime");
+    System.setProperty("java.version", "11.0.0");
+    String version = new ApiClientVersion().toString();
+    assertTrue(
+        "Api version should contain -graalvm suffix", version.matches("gl-java/11.0.0-graalvm.*"));
+  }
+
   public void testSetsApiClientHeaderWithoutOsVersion() {
     System.setProperty("os.name", "My OS");
     System.clearProperty("os.version");


### PR DESCRIPTION
This contributes towards removing the use of the SVM dependency for native image compilation. This code makes use of the org.graalvm.nativeimage.imagecode system property instead of `Substitutions` to set the Java version at image runtime. For reference: https://www.graalvm.org/sdk/javadoc/index.html?constant-values.html

See reproducer: https://github.com/mpeddada1/avoid-substitutions

