### PR TITLE
fix: add error description to batch emptiness validation

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/batch/BatchRequest.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/batch/BatchRequest.java
@@ -228,7 +228,7 @@ public final class BatchRequest {
    */
   public void execute() throws IOException {
     boolean retryAllowed;
-    Preconditions.checkState(!requestInfos.isEmpty());
+    Preconditions.checkState(!requestInfos.isEmpty(), "Batch is empty");
 
     // Log a warning if the user is using the global batch endpoint. In the future, we can turn this
     // into a preconditions check.


### PR DESCRIPTION
When invoking BatchRequest#execute(), we ensure the batch contains at
least one request to process. Previously this check, did not provide any
error message. Now, if the check fails "Batch is empty" will be the
message of the resulting exception.

Related to https://github.com/googleapis/java-storage/issues/694
