### PR TITLE
 fix: Revert remove deprecated class

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/apache/package-info.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/apache/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Google APIs support based on the Apache HTTP Client.
+ *
+ * @since 1.14
+ * @author Yaniv Inbar
+ */
+package com.google.api.client.googleapis.apache;


### PR DESCRIPTION
Reverts googleapis/google-api-java-client#1666