### PR TITLE
fix: update and declare commons-codec dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,11 @@
         <artifactId>google-api-client-xml</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>${project.commons-codec.version}</version>
+      </dependency>
 
       <!-- See README.md about installing this jar -->
       <dependency>
@@ -496,6 +501,7 @@
     <project.http.version>1.42.3</project.http.version>
     <project.httpcore.version>4.4.15</project.httpcore.version>
     <project.httpclient.version>4.5.13</project.httpclient.version>
+    <project.commons-codec.version>1.15</project.commons-codec.version>
     <project.oauth.version>1.34.1</project.oauth.version>
     <project.jsr305.version>3.0.2</project.jsr305.version>
     <project.gson.version>2.8.6</project.gson.version>


### PR DESCRIPTION
This PR manually declares the `commons-codec` version to `1.15`. 

It was discovered that `commons-codec-1.11.jar` has a    a medium vulnerability (https://sca.analysiscenter.veracode.com/vulnerability-database/security/sca/vulnerability/sid-22742/summary). This vulnerability does not have a CVE and it is related to Insecure Input Validation and encoding. 

This is an indirect dpendency that the API client library uses indirectly by using Apache HttpClient.
Any version of codec v1.13+ should have the fix for this vulnerability. 


