### PR TITLE
fix: pinning commons-codec dependency in google-api-client

### DIFF
--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -118,6 +118,10 @@
   </build>
   <dependencies>
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.oauth-client</groupId>
       <artifactId>google-oauth-client</artifactId>
     </dependency>

--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -104,6 +104,13 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>commons-codec:commons-codec</usedDependencies>
+        </configuration>
+      </plugin>
     </plugins>
 
     <resources>

--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -125,6 +125,9 @@
   </build>
   <dependencies>
     <dependency>
+      <!-- google-api-client itself does not touch commons-codec. Its
+        httpclient's dependency. For security advisories in commons-codec, it
+        declares a newer commons-codec than the one declared by httpclient. -->
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -338,6 +338,22 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <version>3.3.0</version>
+          <executions>
+            <execution>
+              <id>analyze</id>
+              <goals>
+                <goal>analyze</goal>
+              </goals>
+              <configuration>
+                <failOnWarning>true</failOnWarning>
+
+                <!-- ignore commons:codec for "used but undeclared", "declared but unused", and "non-test scoped" -->
+                <ignoredDependencies>
+                  <ignoredDependency>commons-codec:commons-codec</ignoredDependency>
+                </ignoredDependencies>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -338,22 +338,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <version>3.3.0</version>
-          <executions>
-            <execution>
-              <id>analyze</id>
-              <goals>
-                <goal>analyze</goal>
-              </goals>
-              <configuration>
-                <failOnWarning>true</failOnWarning>
-
-                <!-- ignore commons:codec for "used but undeclared", "declared but unused", and "non-test scoped" -->
-                <ignoredDependencies>
-                  <ignoredDependency>commons-codec:commons-codec</ignoredDependency>
-                </ignoredDependencies>
-              </configuration>
-            </execution>
-          </executions>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Turns out https://github.com/googleapis/google-api-java-client/pull/2195 only fixed half the issue. `commons-codec` needs to be declared as a dependency within the `google-api-client`'s `pom.xml` as well.