### PR TITLE
fix: media upload to have applicationName as User-Agent

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
@@ -362,25 +362,24 @@ public abstract class AbstractGoogleClientRequest<T> extends GenericData {
     }
   }
 
-  private HttpRequestInitializer mediaUploadRequestUserAgentInitializer(
+  private static HttpRequestInitializer mediaUploadRequestUserAgentInitializer(
       final String applicationName, final HttpRequestInitializer originalInitializer) {
     if (applicationName == null) {
       return originalInitializer;
     }
-    if (originalInitializer != null) {
+    if (originalInitializer == null) {
       return new HttpRequestInitializer() {
         @Override
-        public void initialize(HttpRequest request) throws IOException {
-          originalInitializer.initialize(request);
+        public void initialize(HttpRequest request) {
           HttpHeaders headers = request.getHeaders();
           headers.setUserAgent(applicationName);
         }
       };
     } else {
-      // originalInitializer is null
       return new HttpRequestInitializer() {
         @Override
-        public void initialize(HttpRequest request) {
+        public void initialize(HttpRequest request) throws IOException {
+          originalInitializer.initialize(request);
           HttpHeaders headers = request.getHeaders();
           headers.setUserAgent(applicationName);
         }

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientTest.java
@@ -19,7 +19,6 @@ import com.google.api.client.http.EmptyContent;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpExecuteInterceptor;
 import com.google.api.client.http.HttpRequest;
-import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.InputStreamContent;
@@ -29,7 +28,6 @@ import com.google.api.client.json.Json;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.json.gson.GsonFactory;
-import com.google.api.client.testing.http.HttpTesting;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
@@ -216,7 +214,7 @@ public class AbstractGoogleClientTest extends TestCase {
 
   public void testMediaUpload_applicationNameAsUserAgent() throws Exception {
     MediaTransport fakeTransport = new MediaTransport();
-    String applicationName="Test Application";
+    String applicationName = "Test Application";
     AbstractGoogleClient client =
         new MockGoogleClient.Builder(
                 fakeTransport, TEST_RESUMABLE_REQUEST_URL, "", JSON_OBJECT_PARSER, null)
@@ -235,7 +233,9 @@ public class AbstractGoogleClientTest extends TestCase {
 
     assertEquals(1, fakeTransport.userAgentsRecorded.size());
     for (String userAgent : fakeTransport.userAgentsRecorded) {
-      assertTrue("UserAgent header does not have expected value in requests", userAgent.contains(applicationName));
+      assertTrue(
+          "UserAgent header does not have expected value in requests",
+          userAgent.contains(applicationName));
     }
 
     // This is not leveraging the initializer

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientTest.java
@@ -214,7 +214,7 @@ public class AbstractGoogleClientTest extends TestCase {
 
   public void testMediaUpload_applicationNameAsUserAgent() throws Exception {
     MediaTransport fakeTransport = new MediaTransport();
-    String applicationName = "Test Application";
+    String applicationName = "Foo/1.0 (BAR:Baz/1.0) XYZ/1.0";
     AbstractGoogleClient client =
         new MockGoogleClient.Builder(
                 fakeTransport, TEST_RESUMABLE_REQUEST_URL, "", JSON_OBJECT_PARSER, null)
@@ -226,7 +226,6 @@ public class AbstractGoogleClientTest extends TestCase {
     MockGoogleClientRequest<A> rq =
         new MockGoogleClientRequest<A>(client, "POST", "", null, A.class);
 
-    // Assertion on User-Agent
     rq.initializeMediaUpload(mediaContent);
     MediaHttpUploader mediaHttpUploader = rq.getMediaHttpUploader();
     mediaHttpUploader.upload(new GenericUrl(TEST_RESUMABLE_REQUEST_URL));
@@ -237,15 +236,6 @@ public class AbstractGoogleClientTest extends TestCase {
           "UserAgent header does not have expected value in requests",
           userAgent.contains(applicationName));
     }
-
-    // This is not leveraging the initializer
-    // HttpRequestFactory requestFactory = mediaHttpUploader.getTransport().createRequestFactory();
-    // HttpRequest httpRequest =
-    //    requestFactory.buildPostRequest(HttpTesting.SIMPLE_GENERIC_URL, mediaContent);
-    // String userAgentInSubsequentRequests = httpRequest.getHeaders().getUserAgent();
-    // assertTrue(
-    //    "UserAgent header does not contain application name",
-    //    userAgentInSubsequentRequests.contains("Test Application"));
   }
 
   private static class GZipCheckerInitializer implements HttpRequestInitializer {


### PR DESCRIPTION
Fixes #2222 

- Upload to have applicationName as User-Agent
- request initializer to set user-agent header

How I confirmed the fix:

I locally installed this branch via `mvn install` and specified the SNAPSHOT version of the BOM:

```xml
  <dependencyManagement>
    <dependencies>
      <dependency>
        <groupId>com.google.api-client</groupId>
        <artifactId>google-api-client-bom</artifactId>
        <version>2.1.3-SNAPSHOT</version>
        <type>pom</type>
        <scope>import</scope>
      </dependency>
    </dependencies>
  </dependencyManagement>

  <dependencies>
    <dependency>
      <groupId>com.google.apis</groupId>
      <artifactId>google-api-services-storage</artifactId>
      <version>v1-rev20220705-2.0.0</version>
    </dependency>
...
```

I ran @BenWhitehead 's reproducer (with my small modification):

```java
package org.example;

import static sun.net.www.protocol.http.HttpURLConnection.userAgent;

import com.google.api.client.googleapis.GoogleUtils;
import com.google.api.client.googleapis.media.MediaHttpUploader;
import com.google.api.client.http.GenericUrl;
import com.google.api.client.http.HttpHeaders;
import com.google.api.client.http.HttpRequest;
import com.google.api.client.http.HttpRequestFactory;
import com.google.api.client.http.HttpRequestInitializer;
import com.google.api.client.http.HttpResponse;
import com.google.api.client.http.InputStreamContent;
import com.google.api.client.http.javanet.NetHttpTransport;
import com.google.api.client.json.JsonFactory;
import com.google.api.client.json.gson.GsonFactory;
import com.google.api.services.storage.Storage;
import com.google.api.services.storage.Storage.Objects.Insert;
import com.google.api.services.storage.model.StorageObject;
import com.google.auth.http.HttpCredentialsAdapter;
import com.google.auth.oauth2.GoogleCredentials;
import java.io.ByteArrayInputStream;
import java.nio.charset.StandardCharsets;

public class App 
{
    // Run with VM option to have -Djava.util.logging.config.file=src/main/resources/logging.properties
    public static void main( String[] args ) throws Exception {
        GoogleCredentials credentials = GoogleCredentials.getApplicationDefault();
        String userAgent = "Foo/1.0 (Bar:Baz/1.0) Tomo/1.0";
        HttpCredentialsAdapter credentialsInitializer = new HttpCredentialsAdapter(credentials);

        NetHttpTransport transport = new NetHttpTransport.Builder()
            .trustCertificates(GoogleUtils.getCertificateTrustStore())
            .build();
        HttpRequestFactory rf = transport.createRequestFactory();
        JsonFactory jsonFactory = new GsonFactory();

        Storage storage = new Storage.Builder(rf.getTransport(), jsonFactory, credentialsInitializer)
            .setApplicationName(userAgent)
            .build();


        // Project suztomo-terraform-4f9e48 has this bucket.
        String bucket = "suztomo_test_b252963877"; // TODO: replace with your bucket

        StorageObject storageObject = new StorageObject().setName("temp.txt").setBucket(bucket);
        byte[] bytes = "hi".getBytes(StandardCharsets.UTF_8);
        ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
        InputStreamContent content = new InputStreamContent("text/plain", bais);

        Insert insert = storage.objects().insert(bucket, storageObject, content);
        GenericUrl url = insert.buildHttpRequestUrl();
        MediaHttpUploader mediaHttpUploader = insert.getMediaHttpUploader();

        HttpResponse upload = mediaHttpUploader.upload(url);
        System.out.println("Upload response code: " + upload.getStatusCode() + " " + upload.getStatusMessage());
    }
}
```

 Note that userAgent is used in only `setApplicationName(userAgent)`.

I placed src/main/resources/logging.properties so that it prints debug (FINE-level) log:

```
handlers = java.util.logging.ConsoleHandler
java.util.logging.ConsoleHandler.level = FINE

# Set up logging of HTTP requests and responses (uncomment "level" to show)
com.google.api.level = FINE
```

This is specified via `-Djava.util.logging.config.file=src/main/resources/logging.properties` argument in IntelliJ.

It printed out the expected User-Agent when uploading the data:

```
...
Jan 20, 2023 10:59:01 AM com.google.api.client.http.HttpRequest execute
CONFIG: -------------- REQUEST  --------------
PUT https://storage.googleapis.com/upload/storage/v1/b/suztomo_test_b252963877/o?uploadType=resumable&upload_id=ADPycdstG5t6ppvQpO9MoZROy-k67Qonkt_EFy8fUv5NQOW6hODYzBs8T3iEBy3UD9qy4xz25pnrOc41j_te7WPdu4ZG
Accept-Encoding: gzip
Authorization: <Not Logged>
Content-Range: bytes 0-1/2
User-Agent: Foo/1.0 (Bar:Baz/1.0) Tomo/1.0 Google-HTTP-Java-Client/1.42.3 (gzip)
x-goog-user-project: suztomo-terraform-4f9e48
...
```

