### PR TITLE
build: RenovateBot shouldn't touch requirements.txt

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "config:base"
   ],
+  "ignorePaths": [".kokoro/requirements.txt"],
   "packageRules": [
     {
       "packagePatterns": ["^com.google.appengine:appengine-"],


### PR DESCRIPTION
Following https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/java_library/renovate.json#L15