### PR TITLE
docs: adding deprecated annotation for OOB flow and guide for migration

### DIFF
--- a/google-api-client-java6/src/main/java/com/google/api/client/googleapis/extensions/java6/auth/oauth2/GooglePromptReceiver.java
+++ b/google-api-client-java6/src/main/java/com/google/api/client/googleapis/extensions/java6/auth/oauth2/GooglePromptReceiver.java
@@ -22,6 +22,10 @@ import java.io.IOException;
  * Google OAuth 2.0 abstract verification code receiver that prompts user to paste the code copied
  * from the browser.
  *
+ * <p>This uses deprecated OAuth out-of-band (oob) flow. To migrate to an alternative flow, please
+ * refer to <a href="https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html">Making
+ * Google OAuth interactions safer by using more secure OAuth flows</a>.
+ *
  * <p>Implementation is thread-safe.
  *
  * @since 1.11

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleOAuthConstants.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleOAuthConstants.java
@@ -44,8 +44,13 @@ public class GoogleOAuthConstants {
    * Redirect URI to use for an installed application as specified in <a
    * href="https://developers.google.com/identity/protocols/OAuth2InstalledApp">Using OAuth 2.0 for
    * Mobile & Desktop Apps</a>.
+   *
+   * <p>OAuth out-of-band (oob) flow has been deprecated. To migrate to an alternative flow, please
+   * refer to <a
+   * href="https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html">Making Google
+   * OAuth interactions safer by using more secure OAuth flows</a>.
    */
-  public static final String OOB_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob";
+  @Deprecated public static final String OOB_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob";
 
   private GoogleOAuthConstants() {}
 }


### PR DESCRIPTION
Followup of https://github.com/googleapis/google-api-java-client/pull/2242/files#r1087160426