### PR TITLE
chore: add clirr ignore for deprecated OOB flow

### DIFF
--- a/clirr-ignored-differences.xml
+++ b/clirr-ignored-differences.xml
@@ -34,4 +34,10 @@
     <method>com.google.api.client.http.AbstractHttpContent setMediaType(com.google.api.client.http.HttpMediaType)</method>
     <to>com.google.api.client.http.xml.AbstractXmlHttpContent</to>
   </difference>
+  <!-- Deprecated OOB flow: https://github.com/googleapis/google-api-java-client/pull/2242 -->
+  <difference>
+    <differenceType>6011</differenceType>
+    <className>com/google/api/client/googleapis/auth/oauth2/GoogleOAuthConstants</className>
+    <field>OOB_REDIRECT_URI</field>
+  </difference>
 </differences>


### PR DESCRIPTION
Fixes #2267. This is to unblock failing clirr checks in PRs since v2.2.0, as follow-up to https://github.com/googleapis/google-api-java-client/pull/2242#discussion_r1086200169.

Note: this PR and the ci/windows fix in https://github.com/googleapis/google-api-java-client/pull/2269 mutually unblock each other (and a number of other open PRs in this repo).