### PR TITLE
chore: fix typos

### DIFF
--- a/google-api-client-appengine/src/main/java/com/google/api/client/googleapis/extensions/appengine/auth/oauth2/AppIdentityCredential.java
+++ b/google-api-client-appengine/src/main/java/com/google/api/client/googleapis/extensions/appengine/auth/oauth2/AppIdentityCredential.java
@@ -194,7 +194,7 @@ public class AppIdentityCredential implements HttpRequestInitializer, HttpExecut
      * @param transport the transport for Http calls.
      * @param jsonFactory the factory for Json parsing and formatting.
      * @throws IOException if the credential cannot be created for the current environment, such as
-     *     when the AppIndentityService is not available.
+     *     when the AppIdentityService is not available.
      */
     public AppEngineCredentialWrapper(HttpTransport transport, JsonFactory jsonFactory)
         throws IOException {

--- a/google-api-client-gson/src/main/java/com/google/api/client/googleapis/notifications/json/gson/GsonNotificationCallback.java
+++ b/google-api-client-gson/src/main/java/com/google/api/client/googleapis/notifications/json/gson/GsonNotificationCallback.java
@@ -22,7 +22,7 @@ import com.google.api.client.util.Beta;
 
 /**
  * {@link Beta} <br>
- * A {@link TypedNotificationCallback} which uses an JSON content encoding with {@link
+ * A {@link TypedNotificationCallback} which uses a JSON content encoding with {@link
  * GsonFactory#getDefaultInstance()}.
  *
  * <p>Must NOT be implemented in form of an anonymous class as this will break serialization.

--- a/google-api-client-jackson2/src/main/java/com/google/api/client/googleapis/notifications/json/jackson2/JacksonNotificationCallback.java
+++ b/google-api-client-jackson2/src/main/java/com/google/api/client/googleapis/notifications/json/jackson2/JacksonNotificationCallback.java
@@ -22,7 +22,7 @@ import com.google.api.client.util.Beta;
 
 /**
  * {@link Beta} <br>
- * A {@link TypedNotificationCallback} which uses an JSON content encoding with {@link
+ * A {@link TypedNotificationCallback} which uses a JSON content encoding with {@link
  * GsonFactory#getDefaultInstance()}.
  *
  * <p>Must NOT be implemented in form of an anonymous class as this will break serialization.

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/CloudShellCredential.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/CloudShellCredential.java
@@ -56,9 +56,9 @@ public class CloudShellCredential extends GoogleCredential {
   private static final int READ_TIMEOUT_MS = 5000;
 
   /**
-   * The Cloud Shell back authorization channel uses serialized Javascript Protobufers, preceeded by
+   * The Cloud Shell back authorization channel uses serialized Javascript Protobufers, preceded by
    * the message lengeth and a new line character. However, the request message has no content, so a
-   * token request consists of an empty JsPb, and its 2 character lenth prefix.
+   * token request consists of an empty JsPb, and its 2 character length prefix.
    */
   protected static final String GET_AUTH_TOKEN_REQUEST = "2\n[]";
 

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/DefaultCredentialProvider.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/DefaultCredentialProvider.java
@@ -294,7 +294,7 @@ class DefaultCredentialProvider extends SystemEnvironmentProvider {
     throw OAuth2Utils.exceptionWithCause(
         new RuntimeException(
             String.format(
-                "Unexpcted error trying to determine if runnning on Google App Engine: %s",
+                "Unexpected error trying to determine if running on Google App Engine: %s",
                 cause.getMessage())),
         cause);
   }

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleIdToken.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleIdToken.java
@@ -195,7 +195,7 @@ public class GoogleIdToken extends IdToken {
      *
      * @since 1.10
      *     <p>Upgrade warning: in prior version 1.16 this method accessed {@code "verified_email"}
-     *     and returns a boolean, but starting with verison 1.17, it now accesses {@code
+     *     and returns a boolean, but starting with version 1.17, it now accesses {@code
      *     "email_verified"} and returns a Boolean. Previously, if this value was not specified,
      *     this method would return {@code false}, but now it returns {@code null}.
      */
@@ -218,7 +218,7 @@ public class GoogleIdToken extends IdToken {
      *
      * @since 1.10
      *     <p>Upgrade warning: in prior version 1.16 this method accessed {@code "verified_email"}
-     *     and required a boolean parameter, but starting with verison 1.17, it now accesses {@code
+     *     and required a boolean parameter, but starting with version 1.17, it now accesses {@code
      *     "email_verified"} and requires a Boolean parameter.
      */
     public Payload setEmailVerified(Boolean emailVerified) {

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/package-info.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/package-info.java
@@ -40,7 +40,7 @@
  *       automatically be refreshed using the refresh token (if applicable).
  * </ul>
  *
- * <p>These are the typical steps of the the browser-based client flow specified in <a
+ * <p>These are the typical steps of the browser-based client flow specified in <a
  * href="https://developers.google.com/identity/protocols/OAuth2UserAgent">Using OAuth 2.0 for
  * Client-side Applications</a>:
  *

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/media/MediaHttpUploader.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/media/MediaHttpUploader.java
@@ -235,7 +235,7 @@ public final class MediaHttpUploader {
    */
   private boolean disableGZipContent;
 
-  /** Sleeper. * */
+  /** Sleeper. */
   Sleeper sleeper = Sleeper.DEFAULT;
 
   /**

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/notifications/StoredChannel.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/notifications/StoredChannel.java
@@ -148,7 +148,7 @@ public final class StoredChannel implements Serializable {
   }
 
   /**
-   * Sets the the arbitrary string provided by the client associated with this subscription that is
+   * Sets the arbitrary string provided by the client associated with this subscription that is
    * delivered to the target address with each notification or {@code null} for none.
    */
   public StoredChannel setClientToken(String clientToken) {

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/notifications/json/JsonNotificationCallback.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/notifications/json/JsonNotificationCallback.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 
 /**
  * {@link Beta} <br>
- * A {@link TypedNotificationCallback} which uses an JSON content encoding.
+ * A {@link TypedNotificationCallback} which uses a JSON content encoding.
  *
  * <p>Must NOT be implemented in form of an anonymous class as this will break serialization.
  *


### PR DESCRIPTION
These typos were caught by internal presubmits during the latest import process.
