### PR TITLE
deps: remove unnecessary commons-logging transitive dependency

### DIFF
--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -154,6 +154,14 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
+      <exclusions>
+        <!-- A library should not decide what logging backend
+            the library users should use -->
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-api-java-client/issues/2423

Ensure the checks pass before merge.

=> It turned out the classes from commons-logging are actually used indirectly in this library.

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 s -- in com.google.api.client.googleapis.MethodOverrideTest
[INFO] 
[INFO] Results:
[INFO] 
Error:  Errors: 
Error:    GoogleApacheHttpTransportTest.socketFactoryRegistryHandlerTest:38 » NoClassDefFound org/apache/commons/logging/LogFactory
Error:    GoogleApacheHttpTransportTest>MtlsTransportBaseTest.testNoCertificate:100->buildTrustedTransport:32 » NoClassDefFound Could not initialize class org.apache.http.conn.ssl.SSLConnectionSocketFactory
Error:    GoogleApacheHttpTransportTest>MtlsTransportBaseTest.testNotUseCertificate:82->buildTrustedTransport:32 » NoClassDefFound Could not initialize class org.apache.http.conn.ssl.SSLConnectionSocketFactory
Error:    GoogleApacheHttpTransportTest>MtlsTransportBaseTest.testUseProvidedCertificate:91->buildTrustedTransport:32 » NoClassDefFound Could not initialize class org.apache.http.conn.ssl.SSLConnectionSocketFactory
```