### PR TITLE
docs: latest libraries-bom

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -24,7 +24,7 @@ your `pom.xml`:
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>libraries-bom</artifactId>
-      <version>2.2.0</version>
+      <version>26.34.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>


### PR DESCRIPTION
I'm checking how the document https://googleapis.github.io/google-api-java-client/setup.html is updated by this libraries-bom version upgrade.