### PR TITLE
feat: Add ApiVersion Support

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
@@ -64,6 +64,11 @@ public abstract class AbstractGoogleClientRequest<T> extends GenericData {
   public static final String USER_AGENT_SUFFIX = "Google-API-Java-Client";
 
   private static final String API_CLIENT_HEADER = "X-Goog-Api-Client";
+
+  /**
+   * The generated request class will pass this constant as part of the header if the RPC supports
+   * ApiVersion.
+   */
   protected static final String API_VERSION_HEADER = "X-Google-Api-Version";
 
   /** Google client. */

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
@@ -37,7 +37,9 @@ import com.google.api.client.http.HttpResponseInterceptor;
 import com.google.api.client.http.UriTemplate;
 import com.google.api.client.util.GenericData;
 import com.google.api.client.util.Preconditions;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -62,7 +64,8 @@ public abstract class AbstractGoogleClientRequest<T> extends GenericData {
    */
   public static final String USER_AGENT_SUFFIX = "Google-API-Java-Client";
 
-  private static final String API_VERSION_HEADER = "X-Goog-Api-Client";
+  private static final String API_CLIENT_HEADER = "X-Goog-Api-Client";
+  private static final String API_VERSION_HEADER = "X-Google-Api-Version";
 
   /** Google client. */
   private final AbstractGoogleClient abstractGoogleClient;
@@ -133,7 +136,7 @@ public abstract class AbstractGoogleClientRequest<T> extends GenericData {
       requestHeaders.setUserAgent(USER_AGENT_SUFFIX + "/" + GoogleUtils.VERSION);
     }
     // Set the header for the Api Client version (Java and OS version)
-    requestHeaders.set(API_VERSION_HEADER, ApiClientVersion.DEFAULT_VERSION);
+    requestHeaders.set(API_CLIENT_HEADER, ApiClientVersion.DEFAULT_VERSION);
   }
 
   /**
@@ -310,6 +313,27 @@ public abstract class AbstractGoogleClientRequest<T> extends GenericData {
   public AbstractGoogleClientRequest<T> setRequestHeaders(HttpHeaders headers) {
     this.requestHeaders = headers;
     return this;
+  }
+
+  /**
+   * Set the ApiVersion to be set as part of the header
+   *
+   * <p>ApiVersion cannot be null or empty string ("")
+   */
+  protected void setApiVersionHeader(String apiVersion) {
+    Preconditions.checkState(
+        !Strings.isNullOrEmpty(apiVersion), "ApiVersion cannot be null or empty");
+    requestHeaders.set(API_VERSION_HEADER, apiVersion);
+  }
+
+  /**
+   * Returns the ApiVersion that is set in the header.
+   *
+   * <p>If ApiVersion is not set, null is returned
+   */
+  @VisibleForTesting
+  String getApiVersionHeader() {
+    return (String) requestHeaders.get(API_VERSION_HEADER);
   }
 
   /**

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
@@ -39,7 +39,6 @@ import com.google.api.client.util.GenericData;
 import com.google.api.client.util.Preconditions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
-import com.google.common.base.Strings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -65,7 +64,7 @@ public abstract class AbstractGoogleClientRequest<T> extends GenericData {
   public static final String USER_AGENT_SUFFIX = "Google-API-Java-Client";
 
   private static final String API_CLIENT_HEADER = "X-Goog-Api-Client";
-  private static final String API_VERSION_HEADER = "X-Google-Api-Version";
+  public static final String API_VERSION_HEADER = "X-Google-Api-Version";
 
   /** Google client. */
   private final AbstractGoogleClient abstractGoogleClient;
@@ -313,17 +312,6 @@ public abstract class AbstractGoogleClientRequest<T> extends GenericData {
   public AbstractGoogleClientRequest<T> setRequestHeaders(HttpHeaders headers) {
     this.requestHeaders = headers;
     return this;
-  }
-
-  /**
-   * Set the ApiVersion to be set as part of the header
-   *
-   * <p>ApiVersion cannot be null or empty string ("")
-   */
-  protected void setApiVersionHeader(String apiVersion) {
-    Preconditions.checkState(
-        !Strings.isNullOrEmpty(apiVersion), "ApiVersion cannot be null or empty");
-    requestHeaders.set(API_VERSION_HEADER, apiVersion);
   }
 
   /**

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
@@ -314,11 +314,7 @@ public abstract class AbstractGoogleClientRequest<T> extends GenericData {
     return this;
   }
 
-  /**
-   * Returns the ApiVersion that is set in the header.
-   *
-   * <p>If ApiVersion is not set, null is returned
-   */
+  /** Returns the ApiVersion set in the headers. If ApiVersion is not set, null is returned. */
   @VisibleForTesting
   String getApiVersionHeader() {
     return (String) requestHeaders.get(API_VERSION_HEADER);

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
@@ -64,7 +64,7 @@ public abstract class AbstractGoogleClientRequest<T> extends GenericData {
   public static final String USER_AGENT_SUFFIX = "Google-API-Java-Client";
 
   private static final String API_CLIENT_HEADER = "X-Goog-Api-Client";
-  public static final String API_VERSION_HEADER = "X-Google-Api-Version";
+  protected static final String API_VERSION_HEADER = "X-Google-Api-Version";
 
   /** Google client. */
   private final AbstractGoogleClient abstractGoogleClient;

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/testing/services/MockGoogleClientRequest.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/testing/services/MockGoogleClientRequest.java
@@ -18,6 +18,7 @@ import com.google.api.client.http.HttpContent;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.UriTemplate;
 import com.google.api.client.util.Beta;
+import com.google.common.base.Strings;
 
 /**
  * {@link Beta} <br>
@@ -46,7 +47,31 @@ public class MockGoogleClientRequest<T> extends AbstractGoogleClientRequest<T> {
       String uriTemplate,
       HttpContent content,
       Class<T> responseClass) {
+    this(client, method, uriTemplate, content, responseClass, null);
+  }
+
+  /**
+   * @param client Google client
+   * @param method HTTP Method
+   * @param uriTemplate URI template for the path relative to the base URL. If it starts with a "/"
+   *     the base path from the base URL will be stripped out. The URI template can also be a full
+   *     URL. URI template expansion is done using {@link UriTemplate#expand(String, String, Object,
+   *     boolean)}
+   * @param content HTTP content or {@code null} for none
+   * @param responseClass response class to parse into
+   * @param apiVersion ApiVersion to be passed to the header
+   */
+  public MockGoogleClientRequest(
+      AbstractGoogleClient client,
+      String method,
+      String uriTemplate,
+      HttpContent content,
+      Class<T> responseClass,
+      String apiVersion) {
     super(client, method, uriTemplate, content, responseClass);
+    if (!Strings.isNullOrEmpty(apiVersion)) {
+      getRequestHeaders().set(API_VERSION_HEADER, apiVersion);
+    }
   }
 
   @Override

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/testing/services/MockGoogleClientRequest.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/testing/services/MockGoogleClientRequest.java
@@ -69,6 +69,7 @@ public class MockGoogleClientRequest<T> extends AbstractGoogleClientRequest<T> {
       Class<T> responseClass,
       String apiVersion) {
     super(client, method, uriTemplate, content, responseClass);
+    // Matches generator code: Null or Empty String is not set to the header
     if (!Strings.isNullOrEmpty(apiVersion)) {
       getRequestHeaders().set(API_VERSION_HEADER, apiVersion);
     }

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequestTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequestTest.java
@@ -12,7 +12,6 @@
 
 package com.google.api.client.googleapis.services;
 
-import static org.junit.Assert.assertThrows;
 
 import com.google.api.client.googleapis.GoogleUtils;
 import com.google.api.client.googleapis.services.AbstractGoogleClientRequest.ApiClientVersion;
@@ -39,7 +38,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import junit.framework.TestCase;
-import org.junit.function.ThrowingRunnable;
 
 /**
  * Tests {@link AbstractGoogleClientRequest}.
@@ -252,8 +250,8 @@ public class AbstractGoogleClientRequestTest extends TestCase {
         new MockGoogleClient.Builder(transport, ROOT_URL, SERVICE_PATH, JSON_OBJECT_PARSER, null)
             .build();
     AbstractGoogleClientRequest<Void> request =
-        new MockGoogleClientRequest<>(client, HttpMethods.GET, URI_TEMPLATE, null, Void.class);
-    request.setApiVersionHeader(apiVersion);
+        new MockGoogleClientRequest<>(
+            client, HttpMethods.GET, URI_TEMPLATE, null, Void.class, apiVersion);
     assertEquals(apiVersion, request.getApiVersionHeader());
   }
 
@@ -273,15 +271,9 @@ public class AbstractGoogleClientRequestTest extends TestCase {
         new MockGoogleClient.Builder(transport, ROOT_URL, SERVICE_PATH, JSON_OBJECT_PARSER, null)
             .build();
     final AbstractGoogleClientRequest<Void> request =
-        new MockGoogleClientRequest<>(client, HttpMethods.GET, URI_TEMPLATE, null, Void.class);
-    assertThrows(
-        IllegalStateException.class,
-        new ThrowingRunnable() {
-          @Override
-          public void run() {
-            request.setApiVersionHeader(null);
-          }
-        });
+        new MockGoogleClientRequest<>(
+            client, HttpMethods.GET, URI_TEMPLATE, null, Void.class, null);
+    assertNull(request.getApiVersionHeader());
   }
 
   public void testSetsEmptyStringApiVersionHeader() {
@@ -291,14 +283,7 @@ public class AbstractGoogleClientRequestTest extends TestCase {
             .build();
     final AbstractGoogleClientRequest<Void> request =
         new MockGoogleClientRequest<>(client, HttpMethods.GET, URI_TEMPLATE, null, Void.class);
-    assertThrows(
-        IllegalStateException.class,
-        new ThrowingRunnable() {
-          @Override
-          public void run() {
-            request.setApiVersionHeader("");
-          }
-        });
+    assertNull(request.getApiVersionHeader());
   }
 
   public void testSetsApiClientHeader() throws IOException {

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequestTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequestTest.java
@@ -243,7 +243,7 @@ public class AbstractGoogleClientRequestTest extends TestCase {
     request.executeUnparsed();
   }
 
-  public void testSetsApiVersionHeader() {
+  public void testSetsApiVersionHeader_apiVersionSet() {
     String apiVersion = "testVersion";
     HttpTransport transport = new MockHttpTransport();
     MockGoogleClient client =
@@ -255,7 +255,7 @@ public class AbstractGoogleClientRequestTest extends TestCase {
     assertEquals(apiVersion, request.getApiVersionHeader());
   }
 
-  public void testDoesNotSetsApiVersionHeader() {
+  public void testDoesNotSetsApiVersionHeader_noApiVersionSet() {
     HttpTransport transport = new MockHttpTransport();
     MockGoogleClient client =
         new MockGoogleClient.Builder(transport, ROOT_URL, SERVICE_PATH, JSON_OBJECT_PARSER, null)
@@ -265,7 +265,7 @@ public class AbstractGoogleClientRequestTest extends TestCase {
     assertNull(request.getApiVersionHeader());
   }
 
-  public void testSetsNullApiVersionHeader() {
+  public void testNullApiVersionHeader_noApiVersionSet() {
     HttpTransport transport = new MockHttpTransport();
     MockGoogleClient client =
         new MockGoogleClient.Builder(transport, ROOT_URL, SERVICE_PATH, JSON_OBJECT_PARSER, null)
@@ -276,13 +276,13 @@ public class AbstractGoogleClientRequestTest extends TestCase {
     assertNull(request.getApiVersionHeader());
   }
 
-  public void testSetsEmptyStringApiVersionHeader() {
+  public void testEmptyStringApiVersionHeader_noApiVersionSet() {
     HttpTransport transport = new MockHttpTransport();
     MockGoogleClient client =
         new MockGoogleClient.Builder(transport, ROOT_URL, SERVICE_PATH, JSON_OBJECT_PARSER, null)
             .build();
     final AbstractGoogleClientRequest<Void> request =
-        new MockGoogleClientRequest<>(client, HttpMethods.GET, URI_TEMPLATE, null, Void.class);
+        new MockGoogleClientRequest<>(client, HttpMethods.GET, URI_TEMPLATE, null, Void.class, "");
     assertNull(request.getApiVersionHeader());
   }
 

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequestTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequestTest.java
@@ -12,6 +12,8 @@
 
 package com.google.api.client.googleapis.services;
 
+import static org.junit.Assert.assertThrows;
+
 import com.google.api.client.googleapis.GoogleUtils;
 import com.google.api.client.googleapis.services.AbstractGoogleClientRequest.ApiClientVersion;
 import com.google.api.client.googleapis.testing.services.MockGoogleClient;
@@ -37,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import junit.framework.TestCase;
+import org.junit.function.ThrowingRunnable;
 
 /**
  * Tests {@link AbstractGoogleClientRequest}.
@@ -240,6 +243,62 @@ public class AbstractGoogleClientRequestTest extends TestCase {
     MockGoogleClientRequest<Void> request =
         new MockGoogleClientRequest<>(client, HttpMethods.GET, URI_TEMPLATE, null, Void.class);
     request.executeUnparsed();
+  }
+
+  public void testSetsApiVersionHeader() {
+    String apiVersion = "testVersion";
+    HttpTransport transport = new MockHttpTransport();
+    MockGoogleClient client =
+        new MockGoogleClient.Builder(transport, ROOT_URL, SERVICE_PATH, JSON_OBJECT_PARSER, null)
+            .build();
+    AbstractGoogleClientRequest<Void> request =
+        new MockGoogleClientRequest<>(client, HttpMethods.GET, URI_TEMPLATE, null, Void.class);
+    request.setApiVersionHeader(apiVersion);
+    assertEquals(apiVersion, request.getApiVersionHeader());
+  }
+
+  public void testDoesNotSetsApiVersionHeader() {
+    HttpTransport transport = new MockHttpTransport();
+    MockGoogleClient client =
+        new MockGoogleClient.Builder(transport, ROOT_URL, SERVICE_PATH, JSON_OBJECT_PARSER, null)
+            .build();
+    AbstractGoogleClientRequest<Void> request =
+        new MockGoogleClientRequest<>(client, HttpMethods.GET, URI_TEMPLATE, null, Void.class);
+    assertNull(request.getApiVersionHeader());
+  }
+
+  public void testSetsNullApiVersionHeader() {
+    HttpTransport transport = new MockHttpTransport();
+    MockGoogleClient client =
+        new MockGoogleClient.Builder(transport, ROOT_URL, SERVICE_PATH, JSON_OBJECT_PARSER, null)
+            .build();
+    final AbstractGoogleClientRequest<Void> request =
+        new MockGoogleClientRequest<>(client, HttpMethods.GET, URI_TEMPLATE, null, Void.class);
+    assertThrows(
+        IllegalStateException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() {
+            request.setApiVersionHeader(null);
+          }
+        });
+  }
+
+  public void testSetsEmptyStringApiVersionHeader() {
+    HttpTransport transport = new MockHttpTransport();
+    MockGoogleClient client =
+        new MockGoogleClient.Builder(transport, ROOT_URL, SERVICE_PATH, JSON_OBJECT_PARSER, null)
+            .build();
+    final AbstractGoogleClientRequest<Void> request =
+        new MockGoogleClientRequest<>(client, HttpMethods.GET, URI_TEMPLATE, null, Void.class);
+    assertThrows(
+        IllegalStateException.class,
+        new ThrowingRunnable() {
+          @Override
+          public void run() {
+            request.setApiVersionHeader("");
+          }
+        });
   }
 
   public void testSetsApiClientHeader() throws IOException {

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequestTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequestTest.java
@@ -12,7 +12,6 @@
 
 package com.google.api.client.googleapis.services;
 
-
 import com.google.api.client.googleapis.GoogleUtils;
 import com.google.api.client.googleapis.services.AbstractGoogleClientRequest.ApiClientVersion;
 import com.google.api.client.googleapis.testing.services.MockGoogleClient;


### PR DESCRIPTION
Changes:
- Pass `X-Google-Api-Version` as a header as part of requests if apiVersion exists in the Discovery Doc

Corresponding generator change https://github.com/googleapis/google-api-java-client-services/pull/20930

This PR will go in first then merge in the generator change once this is released and in maven central.

Logs:
```
2024-05-09 14:37:57,833 CONFIG   com.google.api.client.http.HttpTransport - -------------- REQUEST  --------------
GET {URL}
Accept-Encoding: gzip
Authorization: Bearer {BEARER_TOKEN}
User-Agent: DeltaV Example Java App Google-API-Java-Client/2.4.1-SNAPSHOT Google-HTTP-Java-Client/1.44.1 (gzip)
x-goog-user-project: {PROJECT_ID}
x-goog-api-client: gl-java/17.0.10 gdcl/2.4.1 linux/6.6.15
x-google-api-version: v1_20230601
```