### PR TITLE
chore: pinning jakarta servlet API v5

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,11 @@
       "groupName": "AppEngine packages"
     },
     {
+      "packagePatterns": ["jakarta.servlet:jakarta.servlet-api"],
+      "groupName": "Jakarta servlet API"
+      "enabled": false,
+    },
+    {
       "matchPackagePatterns": [
         "^com.google.guava:"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
     },
     {
       "matchPackageNames": ["jakarta.servlet:jakarta.servlet-api"],
-      "groupName": "Jakarta servlet API"
+      "groupName": "Jakarta servlet API",
       "enabled": false,
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
       "groupName": "AppEngine packages"
     },
     {
-      "packagePatterns": ["jakarta.servlet:jakarta.servlet-api"],
+      "matchPackageNames": ["jakarta.servlet:jakarta.servlet-api"],
       "groupName": "Jakarta servlet API"
       "enabled": false,
     },


### PR DESCRIPTION
Pinning jakarta servlet API v5 because v6 does not work with Java 8 compilation. RenovateBot would create unnecessary pull requests such as https://github.com/googleapis/google-api-java-client/pull/2486#issuecomment-2129988178.

Using matchPackageNames https://docs.renovatebot.com/configuration-options/#matchpackagenames. No regular expression is needed.