### PR TITLE
chore: Add metadata field to GoogleJsonError ErrorInfo class.

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/json/GoogleJsonError.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/json/GoogleJsonError.java
@@ -22,9 +22,11 @@ import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.util.Data;
 import com.google.api.client.util.Key;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Data class representing the Google JSON error response content, as documented for example in <a
@@ -191,6 +193,7 @@ public class GoogleJsonError extends GenericJson {
     @Key private String detail;
     @Key private String reason;
     @Key private List<ParameterViolations> parameterViolations;
+    @Key private Map<String, String> metadata;
 
     public String getType() {
       return type;
@@ -227,6 +230,14 @@ public class GoogleJsonError extends GenericJson {
      */
     public void setParameterViolations(List<ParameterViolations> parameterViolations) {
       this.parameterViolations = ImmutableList.copyOf(parameterViolations);
+    }
+
+    public Map<String, String> getMetadata() {
+      return metadata;
+    }
+
+    public void setMetadata(Map<String, String> metadata) {
+      this.metadata = ImmutableMap.copyOf(metadata);
     }
   }
 

--- a/google-api-client/src/test/resources/com/google/api/client/googleapis/json/errorWithMetadataInDetails.json
+++ b/google-api-client/src/test/resources/com/google/api/client/googleapis/json/errorWithMetadataInDetails.json
@@ -1,0 +1,17 @@
+{
+  "error": {
+    "code": 400,
+    "message": "API key not valid. Please pass a valid API key.",
+    "status": "INVALID_ARGUMENT",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        "reason": "API_KEY_INVALID",
+        "domain": "googleapis.com",
+        "metadata": {
+          "service": "translate.googleapis.com"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
- The HTTP error contains a metadata field, which is dropped by the library. See
https://cloud.google.com/apis/design/errors#http_mapping
- Fixes b/346332757