### PR TITLE
docs: fix error response format url

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/json/GoogleJsonError.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/json/GoogleJsonError.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 /**
  * Data class representing the Google JSON error response content, as documented for example in <a
- * href="https://developers.google.com/url-shortener/v1/getting_started#errors">Error responses</a>.
+ * href="https://cloud.google.com/apis/design/errors">Error responses</a>.
  *
  * @since 1.4
  * @author Yaniv Inbar

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/json/GoogleJsonResponseException.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/json/GoogleJsonResponseException.java
@@ -29,8 +29,7 @@ import java.io.IOException;
 /**
  * Exception thrown when an error status code is detected in an HTTP response to a Google API that
  * uses the JSON format, using the format specified in <a href=
- * "https://developers.google.com/url-shortener/v1/getting_started?csw=1#errors">Error
- * Responses</a>.
+ * "https://cloud.google.com/apis/design/errors">Error Responses</a>.
  *
  * <p>To execute a request, call {@link #execute(JsonFactory, HttpRequest)}. This will throw a
  * {@link GoogleJsonResponseException} on an error response. To get the structured details, use


### PR DESCRIPTION
Fixes #2513 

https://developers.google.com/api-client-library/java/google-api-java-client/errors points to https://cloud.google.com/apis/design/errors for defining the error response format.