### PR TITLE
feat: allow cached ADC to be refreshed

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/DefaultCredentialProvider.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/DefaultCredentialProvider.java
@@ -82,6 +82,7 @@ class DefaultCredentialProvider extends SystemEnvironmentProvider {
    * authorize the whole application. This is the built-in service account if running on Google
    * Compute Engine or the credentials file from the path in the environment variable
    * GOOGLE_APPLICATION_CREDENTIALS.
+   * If the credentials have been cached, the cached credential will be returned.
    *
    * @param transport the transport for Http calls.
    * @param jsonFactory the factory for Json parsing and formatting.
@@ -90,8 +91,28 @@ class DefaultCredentialProvider extends SystemEnvironmentProvider {
    */
   final GoogleCredential getDefaultCredential(HttpTransport transport, JsonFactory jsonFactory)
       throws IOException {
+    return getDefaultCredential(transport, jsonFactory, false);
+  }
+
+  /**
+   * {@link Beta} <br>
+   * Returns the Application Default Credentials.
+   *
+   * <p>Returns the Application Default Credentials which are credentials that identify and
+   * authorize the whole application. This is the built-in service account if running on Google
+   * Compute Engine or the credentials file from the path in the environment variable
+   * GOOGLE_APPLICATION_CREDENTIALS.
+   *
+   * @param transport the transport for Http calls.
+   * @param jsonFactory the factory for Json parsing and formatting.
+   * @param resetCachedCredentials if true, the cached credential will be reset.
+   * @return the credential instance.
+   * @throws IOException if the credential cannot be created in the current environment.
+   */
+  final GoogleCredential getDefaultCredential(HttpTransport transport, JsonFactory jsonFactory, boolean resetCachedCredentials)
+      throws IOException {
     synchronized (this) {
-      if (cachedCredential == null) {
+      if (cachedCredential == null || resetCachedCredentials) {
         cachedCredential = getDefaultCredentialUnsynchronized(transport, jsonFactory);
       }
       if (cachedCredential != null) {

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/DefaultCredentialProvider.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/DefaultCredentialProvider.java
@@ -81,8 +81,8 @@ class DefaultCredentialProvider extends SystemEnvironmentProvider {
    * <p>Returns the Application Default Credentials which are credentials that identify and
    * authorize the whole application. This is the built-in service account if running on Google
    * Compute Engine or the credentials file from the path in the environment variable
-   * GOOGLE_APPLICATION_CREDENTIALS.
-   * If the credentials have been cached, the cached credential will be returned.
+   * GOOGLE_APPLICATION_CREDENTIALS. If the credentials have been cached, the cached credential will
+   * be returned.
    *
    * @param transport the transport for Http calls.
    * @param jsonFactory the factory for Json parsing and formatting.
@@ -109,7 +109,8 @@ class DefaultCredentialProvider extends SystemEnvironmentProvider {
    * @return the credential instance.
    * @throws IOException if the credential cannot be created in the current environment.
    */
-  final GoogleCredential getDefaultCredential(HttpTransport transport, JsonFactory jsonFactory, boolean resetCachedCredentials)
+  final GoogleCredential getDefaultCredential(
+      HttpTransport transport, JsonFactory jsonFactory, boolean resetCachedCredentials)
       throws IOException {
     synchronized (this) {
       if (cachedCredential == null || resetCachedCredentials) {

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleCredential.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleCredential.java
@@ -181,13 +181,16 @@ public class GoogleCredential extends Credential {
    * authorize the whole application. This is the built-in service account if running on Google
    * Compute Engine or the credentials file from the path in the environment variable
    * GOOGLE_APPLICATION_CREDENTIALS.
+   *
    * @param resetCachedCredentials whether to reset the cached credentials
    * @return the credential instance.
    * @throws IOException if the credential cannot be created in the current environment.
    */
   @Beta
-  public static GoogleCredential getApplicationDefault(boolean resetCachedCredentials) throws IOException {
-    return getApplicationDefault(Utils.getDefaultTransport(), Utils.getDefaultJsonFactory(), resetCachedCredentials);
+  public static GoogleCredential getApplicationDefault(boolean resetCachedCredentials)
+      throws IOException {
+    return getApplicationDefault(
+        Utils.getDefaultTransport(), Utils.getDefaultJsonFactory(), resetCachedCredentials);
   }
 
   /**
@@ -207,10 +210,12 @@ public class GoogleCredential extends Credential {
    */
   @Beta
   public static GoogleCredential getApplicationDefault(
-      HttpTransport transport, JsonFactory jsonFactory, boolean resetCachedCredentials) throws IOException {
+      HttpTransport transport, JsonFactory jsonFactory, boolean resetCachedCredentials)
+      throws IOException {
     Preconditions.checkNotNull(transport);
     Preconditions.checkNotNull(jsonFactory);
-    return defaultCredentialProvider.getDefaultCredential(transport, jsonFactory, resetCachedCredentials);
+    return defaultCredentialProvider.getDefaultCredential(
+        transport, jsonFactory, resetCachedCredentials);
   }
 
   /**
@@ -607,7 +612,9 @@ public class GoogleCredential extends Credential {
       return (Builder) super.setJsonFactory(jsonFactory);
     }
 
-    /** @since 1.9 */
+    /**
+     * @since 1.9
+     */
     @Override
     public Builder setClock(Clock clock) {
       return (Builder) super.setClock(clock);

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleCredential.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleCredential.java
@@ -153,7 +153,7 @@ public class GoogleCredential extends Credential {
   static final String SERVICE_ACCOUNT_FILE_TYPE = "service_account";
 
   @Beta
-  private static DefaultCredentialProvider defaultCredentialProvider =
+  private static final DefaultCredentialProvider defaultCredentialProvider =
       new DefaultCredentialProvider();
 
   /**
@@ -170,7 +170,47 @@ public class GoogleCredential extends Credential {
    */
   @Beta
   public static GoogleCredential getApplicationDefault() throws IOException {
-    return getApplicationDefault(Utils.getDefaultTransport(), Utils.getDefaultJsonFactory());
+    return getApplicationDefault(Utils.getDefaultTransport(), Utils.getDefaultJsonFactory(), false);
+  }
+
+  /**
+   * {@link Beta} <br>
+   * Returns the Application Default Credentials.
+   *
+   * <p>Returns the Application Default Credentials which are credentials that identify and
+   * authorize the whole application. This is the built-in service account if running on Google
+   * Compute Engine or the credentials file from the path in the environment variable
+   * GOOGLE_APPLICATION_CREDENTIALS.
+   * @param resetCachedCredentials whether to reset the cached credentials
+   * @return the credential instance.
+   * @throws IOException if the credential cannot be created in the current environment.
+   */
+  @Beta
+  public static GoogleCredential getApplicationDefault(boolean resetCachedCredentials) throws IOException {
+    return getApplicationDefault(Utils.getDefaultTransport(), Utils.getDefaultJsonFactory(), resetCachedCredentials);
+  }
+
+  /**
+   * {@link Beta} <br>
+   * Returns the Application Default Credentials.
+   *
+   * <p>Returns the Application Default Credentials which are credentials that identify and
+   * authorize the whole application. This is the built-in service account if running on Google
+   * Compute Engine or the credentials file from the path in the environment variable
+   * GOOGLE_APPLICATION_CREDENTIALS.
+   *
+   * @param resetCachedCredentials whether to reset the cached credentials.
+   * @param transport the transport for Http calls.
+   * @param jsonFactory the factory for Json parsing and formatting.
+   * @return the credential instance.
+   * @throws IOException if the credential cannot be created in the current environment.
+   */
+  @Beta
+  public static GoogleCredential getApplicationDefault(
+      HttpTransport transport, JsonFactory jsonFactory, boolean resetCachedCredentials) throws IOException {
+    Preconditions.checkNotNull(transport);
+    Preconditions.checkNotNull(jsonFactory);
+    return defaultCredentialProvider.getDefaultCredential(transport, jsonFactory, resetCachedCredentials);
   }
 
   /**
@@ -190,9 +230,7 @@ public class GoogleCredential extends Credential {
   @Beta
   public static GoogleCredential getApplicationDefault(
       HttpTransport transport, JsonFactory jsonFactory) throws IOException {
-    Preconditions.checkNotNull(transport);
-    Preconditions.checkNotNull(jsonFactory);
-    return defaultCredentialProvider.getDefaultCredential(transport, jsonFactory);
+    return getApplicationDefault(transport, jsonFactory, false);
   }
 
   /**

--- a/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleCredential.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleCredential.java
@@ -140,8 +140,8 @@ import java.util.Collections;
  * response handler, take a look at the sample usage for {@link HttpExecuteInterceptor} and {@link
  * HttpUnsuccessfulResponseHandler}, which are interfaces that this class also implements.
  *
- * @since 1.7
  * @author Yaniv Inbar
+ * @since 1.7
  * @deprecated Please use <a href="https://github.com/googleapis/google-auth-library-java">
  *     google-auth-library</a> for handling Application Default Credentials and other non-OAuth2
  *     based authentication.

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/auth/oauth2/DefaultCredentialProviderTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/auth/oauth2/DefaultCredentialProviderTest.java
@@ -87,7 +87,6 @@ public class DefaultCredentialProviderTest extends TestCase {
     assertSame(JSON_FACTORY, defaultCredential.getJsonFactory());
   }
 
-
   public void testGetApplicationDefaultResetCacheTrueReturnsNewCredentials() throws IOException {
     TestDefaultCredentialProvider testProvider = new TestDefaultCredentialProvider();
     HttpTransport transport = new MockHttpTransport();

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/auth/oauth2/DefaultCredentialProviderTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/auth/oauth2/DefaultCredentialProviderTest.java
@@ -87,6 +87,20 @@ public class DefaultCredentialProviderTest extends TestCase {
     assertSame(JSON_FACTORY, defaultCredential.getJsonFactory());
   }
 
+
+  public void testGetApplicationDefaultResetCacheTrueReturnsNewCredentials() throws IOException {
+    TestDefaultCredentialProvider testProvider = new TestDefaultCredentialProvider();
+    HttpTransport transport = new MockHttpTransport();
+    testProvider.addType(
+        DefaultCredentialProvider.APP_ENGINE_CREDENTIAL_CLASS, MockAppEngineCredential.class);
+    testProvider.addType(GAE_SIGNAL_CLASS, MockAppEngineSystemProperty.class);
+    Credential credential1 = testProvider.getDefaultCredential(transport, JSON_FACTORY, false);
+    Credential credential2 = testProvider.getDefaultCredential(transport, JSON_FACTORY, false);
+    Credential credential3 = testProvider.getDefaultCredential(transport, JSON_FACTORY, true);
+    assertSame(credential1, credential2);
+    assertNotSame(credential2, credential3);
+  }
+
   public void testDefaultCredentialAppEngineComponentOffAppEngineGivesNotFoundError() {
     HttpTransport transport = new MockHttpTransport();
     TestDefaultCredentialProvider testProvider = new TestDefaultCredentialProvider();


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-api-java-client/issues/2541

This introduces the new method `public static GoogleCredential getApplicationDefault(boolean resetCachedCredentials)` which will reset the cached credentials when the argument is `true`.
