### PR TITLE
ci: wrap nexus-staging-maven-plugin in a profile

### DIFF
--- a/google-api-client-bom/pom.xml
+++ b/google-api-client-bom/pom.xml
@@ -111,17 +111,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.7.0</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>sonatype-nexus-staging</serverId>
-          <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>false</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.11.2</version>
@@ -157,6 +146,57 @@
   </build>
 
   <profiles>
+    <!-- Because the BOM artifact does not need to inherit other properties such as dependencies
+    in the root pom.xml, this needs to define publication-related profiles. -->
+    <profile>
+      <!-- By default, we release artifacts to Sonatype, which requires
+          nexus-staging-maven-plugin. -->
+      <id>release-sonatype</id>
+      <activation>
+        <property>
+          <!-- Only when we use the release-gcp-artifact-registry profile,
+          which comes with artifact-registry-url property, this profile is
+          turned off. -->
+          <name>!artifact-registry-url</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.13</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>sonatype-nexus-staging</serverId>
+              <nexusUrl>https://google.oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>false</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+          this release-gcp-artifact-registry profile:
+          mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+              -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+          -->
+      <id>release-gcp-artifact-registry</id>
+      <properties>
+        <artifact-registry-url>artifactregistry://please-define-artifact-registry-url-property</artifact-registry-url>
+      </properties>
+      <distributionManagement>
+        <repository>
+          <id>gcp-artifact-registry-repository</id>
+          <url>${artifact-registry-url}</url>
+        </repository>
+        <snapshotRepository>
+          <id>gcp-artifact-registry-repository</id>
+          <url>${artifact-registry-url}</url>
+        </snapshotRepository>
+      </distributionManagement>
+    </profile>
     <profile>
       <id>release-sign-artifacts</id>
       <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -506,10 +506,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
         <version>2.13</version>
@@ -721,6 +717,48 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <!-- By default, we release artifacts to Sonatype, which requires
+          nexus-staging-maven-plugin. -->
+      <id>release-sonatype</id>
+      <activation>
+        <property>
+          <!-- Only when we use the release-gcp-artifact-registry profile,
+          which comes with artifact-registry-url property, this profile is
+          turned off. -->
+          <name>!artifact-registry-url</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <!-- Optionally, we can publish the artifacts to GCP Artifact Registry specifying
+          this release-gcp-artifact-registry profile:
+          mvn deploy -P=release-gcp-artifact-registry -P=-release-sonatype \
+              -Dartifact-registry-url=artifactregistry://us-maven.pkg.dev/...
+          -->
+      <id>release-gcp-artifact-registry</id>
+      <properties>
+        <artifact-registry-url>artifactregistry://please-define-artifact-registry-url-property</artifact-registry-url>
+      </properties>
+      <distributionManagement>
+        <repository>
+          <id>gcp-artifact-registry-repository</id>
+          <url>${artifact-registry-url}</url>
+        </repository>
+        <snapshotRepository>
+          <id>gcp-artifact-registry-repository</id>
+          <url>${artifact-registry-url}</url>
+        </snapshotRepository>
+      </distributionManagement>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
The nexus-staging-maven-plugin extension is wrapped by a profile "release-sonatype" because the extension interferes with maven-deploy-plugin. Example error: `[ERROR] Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.7.0:deploy (injected-nexus-deploy) on project google-api-client-bom: Execution injected-nexus-deploy of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.7.0:deploy failed: Server credentials with ID "sonatype-nexus-staging" not found! -> [Help 1]`

We use maven-deploy-plugin to upload artifacts to Artifact Registry, as well as to locally create bundle for Central Portal API.

This follows https://github.com/googleapis/google-oauth-java-client/commit/8e6ce3aeea86c3019677d599f0e0d82ffdadbd04.