### PR TITLE
fix: preserve Data null sentinels with R8

### DIFF
--- a/docs/android.md
+++ b/docs/android.md
@@ -35,6 +35,14 @@ public void onCreate(Bundle savedInstanceState) {
 Begin by reading the [Android development instructions][http-client-android] for
 the Google HTTP Client Library for Java.
 
+## R8 and ProGuard
+
+The `google-api-client` artifact includes consumer rules required by the
+library. If your build does not automatically consume rules from dependency
+JARs, include the rules from
+[`google-api-client.pro`][google-api-client-proguard] in your R8 or ProGuard
+configuration.
+
 ## Authentication
 
 As described in the [Android development instructions][http-client-android], the
@@ -75,5 +83,6 @@ if (files == null || files.isEmpty()) {
 [play-services]: https://developer.android.com/google/play-services/index.html
 [account-manager]: http://developer.android.com/reference/android/accounts/AccountManager.html
 [http-client-android]: https://github.com/googleapis/google-http-java-client/wiki/Android
+[google-api-client-proguard]: https://github.com/googleapis/google-api-java-client/blob/main/google-api-client/src/main/resources/META-INF/proguard/google-api-client.pro
 [oauth2-android]: https://github.com/googleapis/google-api-java-client#oauth2-android
 [quickstart]: https://developers.google.com/drive/api/v3/quickstart/java

--- a/google-api-client-assembly/proguard-google-api-client.txt
+++ b/google-api-client-assembly/proguard-google-api-client.txt
@@ -10,6 +10,13 @@
   @com.google.api.client.util.Key <fields>;
 }
 
+# Data's magic null values rely on reference identity. Keep R8 from replacing
+# wrapper instances with canonical values such as Boolean.TRUE.
+
+-keepclassmembers class com.google.api.client.util.Data {
+  public static final *** NULL_*;
+}
+
 # Needed by google-http-client-android when linking against an older platform version
 
 -dontwarn com.google.api.client.extensions.android.**

--- a/google-api-client/src/main/resources/META-INF/proguard/google-api-client.pro
+++ b/google-api-client/src/main/resources/META-INF/proguard/google-api-client.pro
@@ -1,2 +1,9 @@
 # https://github.com/googleapis/google-api-java-client/issues/1450
 -keep public class com.google.api.client.googleapis.GoogleUtils
+
+# Data's magic null values rely on reference identity. Keep R8 from replacing
+# wrapper instances with canonical values such as Boolean.TRUE.
+# https://github.com/googleapis/google-api-java-client/issues/2603
+-keepclassmembers class com.google.api.client.util.Data {
+  public static final *** NULL_*;
+}


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-api-java-client/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #2603  ☕️

This change adds consumer ProGuard rules that preserve the reference identity of `Data.NULL_*` sentinel values. This prevents R8 from replacing wrapper sentinel instances with canonical values such as `Boolean.TRUE`, which caused legitimate Boolean query parameters to be treated as null and omitted.

The rule was added to both the packaged consumer configuration and the legacy assembly configuration. The Android documentation now explains how to include these rules when dependency JAR rules are not consumed automatically.

Validation performed:

- ProGuard configuration parsing succeeded.
- Maven resource processing succeeded.
- `git diff --check` passed.
- The full build could not be completed locally because the installed JDK no longer supports the repository's Java 7 source and target settings.